### PR TITLE
sc-1254: user device should have an explicit last login at

### DIFF
--- a/change/@passageidentity-passage-node-61cca3ed-1ad5-4f61-a6d9-ff78c62d4b7c.json
+++ b/change/@passageidentity-passage-node-61cca3ed-1ad5-4f61-a6d9-ff78c62d4b7c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add fields to device type",
+  "packageName": "@passageidentity/passage-node",
+  "email": "luis.ramirez@passage.id",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@passageidentity/passage-node",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@passageidentity/passage-node",
-      "version": "1.10.2",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4",

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -12,9 +12,12 @@ interface UserEventInfo {
 
 interface WebAuthnDevices {
   id: string;
+  cred_id: string;
   friendly_name: string;
-  usage_count: string;
-  last_used: string;
+  usage_count: number;
+  updated_at: string;
+  created_at: string;
+  last_login_at: string;
 }
 
 enum UserStatus {


### PR DESCRIPTION
-   add `last_login_at` to device type

#### Minor changes

-   change `usage_count` type from number to string
-   add rest of fields returned by device API:
    - `cred_id`
    - `updated_at`
    - `created_at`
---
Before device names could be updated, the `updated_at` value indicated the last login.
Now it indicates the last login _or_ the last name change.

This new `last_login_at` value accurately reflects the last login, even after a device name change.
