### PR TITLE
Chore: Breakout test suite action for workflow_dispatch access

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Tests on PR
+
+on:
+  workflow_dispatch:
+
+env:
+  API_KEY: ${{ secrets.API_KEY }}
+  APP_ID: ${{ secrets.APP_ID }}
+  APP_TOKEN: ${{ secrets.APP_TOKEN }}
+  EXAMPLE_USER_ID: ${{ secrets.EXAMPLE_USER_ID }}
+  PUBLIC_KEY: ${{ secrets.PUBLIC_KEY }}
+
+jobs:
+  test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: npm i
+
+      - name: Unit Test
+        run: npm run test


### PR DESCRIPTION
**Is this a breaking change?**
No 

**Describe this change**
This breaks out just the test suite items into its own workflow that can be triggered via a dispatch. This will allow us to run the SDK test suite in actions in other dependent repos. 