### PR TITLE
Chore: Update tests to expect case insensitive email responses on update 

### DIFF
--- a/change/@passageidentity-passage-node-d0353bed-d405-4c3e-9dc2-9ab43e71ba97.json
+++ b/change/@passageidentity-passage-node-d0353bed-d405-4c3e-9dc2-9ab43e71ba97.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update tests to expect lowercase emails",
+  "packageName": "@passageidentity/passage-node",
+  "email": "mac.evans@passage.id",
+  "dependentChangeType": "none"
+}

--- a/tests/test-suite.test.ts
+++ b/tests/test-suite.test.ts
@@ -91,11 +91,11 @@ describe("Passage API Requests", () => {
       });
       expect(updatedUser).toHaveProperty(
         "email",
-        "changeEmailTest+nodeSDK@passage.id"
+        "changeemailtest+nodesdk@passage.id"
       );
 
       await passage.user.update(updatedUser.id, {
-        email: "defaultTestEmail+nodeSDK@passage.id",
+        email: "defaulttestemail+nodesdk@passage.id",
       });
     });
     test("update User Phone", async () => {


### PR DESCRIPTION
**What type of change is this?**
A cleanup to tests. There is no functionality changes. 

**Describe the change**
This updates our tests to expect the proper behavior of lower case responses of emails from the API. 