### PR TITLE
Chore: Correct return type for authenticateRequest function 

### DIFF
--- a/change/@passageidentity-passage-node-3996f7cd-63ab-4d40-9278-598188a5db0c.json
+++ b/change/@passageidentity-passage-node-3996f7cd-63ab-4d40-9278-598188a5db0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove boolean value from promise return type  value on authenticateRequest",
+  "packageName": "@passageidentity/passage-node",
+  "email": "mac.evans@passage.id",
+  "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@passageidentity/passage-node",
-  "version": "1.11.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@passageidentity/passage-node",
-      "version": "1.11.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.4",

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -15,29 +15,29 @@ const AUTH_CACHE: AUTHCACHE = {};
  * Passage Class
  */
 export default class Passage {
-  appID: string;
-  #apiKey: string | undefined;
-  authStrategy: AuthStrategy;
-  user: User;
+    appID: string;
+    #apiKey: string | undefined;
+    authStrategy: AuthStrategy;
+    user: User;
 
-  /**
+    /**
    * Initialize a new Passage instance.
    * @param {PassageConfig} config The default config for Passage initialization
    */
-  constructor(config?: PassageConfig) {
-    if (!config?.appID) {
-      throw new Error(
-        "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
-      );
+    constructor(config?: PassageConfig) {
+        if (!config?.appID) {
+            throw new Error(
+                "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
+            );
+        }
+        this.appID = config.appID;
+        this.#apiKey = config?.apiKey;
+        this.user = new User(config);
+
+        this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
     }
-    this.appID = config.appID;
-    this.#apiKey = config?.apiKey;
-    this.user = new User(config);
 
-    this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
-  }
-
-  /**
+    /**
    * Authenticate request with a cookie, or header. If no authentication
    * strategy is given, authenticate the request via cookie (default
    * authentication strategy).
@@ -45,239 +45,239 @@ export default class Passage {
    * @param {Request} req Express request
    * @return {string} UserID of the Passage user
    */
-  async authenticateRequest(req: Request): Promise<string> {
-    if (this.authStrategy == "HEADER") {
-      return this.authenticateRequestWithHeader(req);
-    } else {
-      return this.authenticateRequestWithCookie(req);
+    async authenticateRequest(req: Request): Promise<string> {
+        if (this.authStrategy == "HEADER") {
+            return this.authenticateRequestWithHeader(req);
+        } else {
+            return this.authenticateRequestWithCookie(req);
+        }
     }
-  }
 
-  /**
+    /**
    * Set API key for this Passage instance
    * @param {string} _apiKey
    */
-  set apiKey(_apiKey) {
-    this.#apiKey = _apiKey;
-  }
+    set apiKey(_apiKey) {
+        this.#apiKey = _apiKey;
+    }
 
-  /**
+    /**
    * Get API key for this Passage instance
    * @return {string | undefined} Passage API Key
    */
-  get apiKey(): string | undefined {
-    return this.#apiKey;
-  }
+    get apiKey(): string | undefined {
+        return this.#apiKey;
+    }
 
-  /**
+    /**
    * Fetch the corresponding JWKS for this app.
    *
    * @param {boolean} resetCache Optional value to specify whether or not the cache should be reset
    * @return {JWKS} JWKS for this app.
    */
-  async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
+    async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
     // use cached value if found
-    if (
-      AUTH_CACHE[this.appID] !== undefined &&
+        if (
+            AUTH_CACHE[this.appID] !== undefined &&
       Object.keys(AUTH_CACHE).length > 0 &&
       !resetCache
-    ) {
-      return AUTH_CACHE[this.appID]["jwks"];
-    }
-
-    const jwks: { [kid: string]: JWK } = await axios
-      .get(
-        `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
-      )
-      .catch((err) => {
-        throw new Error(
-          `Could not fetch appID\'s JWKs. HTTP status: ${err.response.status}`
-        );
-      })
-      .then((res) => {
-        const jwks = res.data.keys;
-        const formattedJWKS: JWKS = {};
-
-        // format jwks for cache
-        for (const jwk of jwks) {
-          formattedJWKS[jwk.kid] = jwk;
+        ) {
+            return AUTH_CACHE[this.appID]["jwks"];
         }
 
-        Object.assign(AUTH_CACHE, {
-          [this.appID]: { jwks: { ...formattedJWKS } },
-        });
-        return formattedJWKS;
-      });
+        const jwks: { [kid: string]: JWK } = await axios
+            .get(
+                `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
+            )
+            .catch((err) => {
+                throw new Error(
+                    `Could not fetch appID\'s JWKs. HTTP status: ${err.response.status}`
+                );
+            })
+            .then((res) => {
+                const jwks = res.data.keys;
+                const formattedJWKS: JWKS = {};
 
-    return jwks;
-  }
+                // format jwks for cache
+                for (const jwk of jwks) {
+                    formattedJWKS[jwk.kid] = jwk;
+                }
 
-  /**
+                Object.assign(AUTH_CACHE, {
+                    [this.appID]: { jwks: { ...formattedJWKS } },
+                });
+                return formattedJWKS;
+            });
+
+        return jwks;
+    }
+
+    /**
    * Authenticate a request via the http header.
    *
    * @param {Request} req Express request
    * @return {string} User ID for Passage User
    */
-  async authenticateRequestWithHeader(req: Request): Promise<string> {
-    const { authorization } = req.headers;
+    async authenticateRequestWithHeader(req: Request): Promise<string> {
+        const { authorization } = req.headers;
 
-    if (!authorization) {
-      throw new Error(
-        "Header authorization not found. You must catch this error."
-      );
-    } else {
-      const authToken = authorization.split(" ")[1];
-      const userID = await this.validAuthToken(authToken);
-      if (userID) {
-        return userID;
-      } else {
-        throw new Error("Auth token is invalid");
-      }
+        if (!authorization) {
+            throw new Error(
+                "Header authorization not found. You must catch this error."
+            );
+        } else {
+            const authToken = authorization.split(" ")[1];
+            const userID = await this.validAuthToken(authToken);
+            if (userID) {
+                return userID;
+            } else {
+                throw new Error("Auth token is invalid");
+            }
+        }
     }
-  }
 
-  /**
+    /**
    * Authenticate request via cookie.
    *
    * @param {Request} req Express request
    * @return {string} UserID for Passage User
    */
-  async authenticateRequestWithCookie(req: Request): Promise<string> {
-    if (!req.headers?.cookie) {
-      throw new Error(
-        "Could not find valid cookie for authentication. You must catch this error."
-      );
+    async authenticateRequestWithCookie(req: Request): Promise<string> {
+        if (!req.headers?.cookie) {
+            throw new Error(
+                "Could not find valid cookie for authentication. You must catch this error."
+            );
+        }
+
+        const cookies = {} as { psg_auth_token: string };
+
+        req.headers.cookie?.split(";").forEach((cookie) => {
+            const parts = cookie.match(/(.*?)=(.*)$/);
+            if (parts) {
+                const key = parts[1].trim();
+                const value = parts[2].trim() || "";
+                // @ts-ignore
+                cookies[key] = value;
+            }
+        });
+
+        const passageAuthToken = cookies.psg_auth_token;
+        if (passageAuthToken) {
+            const userID = await this.validAuthToken(passageAuthToken);
+            if (userID) return userID;
+            else {
+                throw new Error(
+                    "Could not validate auth token. You must catch this error."
+                );
+            }
+        } else {
+            throw new Error(
+                "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
+            );
+        }
     }
 
-    const cookies = {} as { psg_auth_token: string };
-
-    req.headers.cookie?.split(";").forEach((cookie) => {
-      const parts = cookie.match(/(.*?)=(.*)$/);
-      if (parts) {
-        const key = parts[1].trim();
-        const value = parts[2].trim() || "";
-        // @ts-ignore
-        cookies[key] = value;
-      }
-    });
-
-    const passageAuthToken = cookies.psg_auth_token;
-    if (passageAuthToken) {
-      const userID = await this.validAuthToken(passageAuthToken);
-      if (userID) return userID;
-      else {
-        throw new Error(
-          "Could not validate auth token. You must catch this error."
-        );
-      }
-    } else {
-      throw new Error(
-        "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
-      );
-    }
-  }
-
-  /**
+    /**
    *
    * @param {string} kid the KID from the authToken to determine which JWK to use.
    * @return {Promise<JWK | undefined>} the JWK to be used for decoding an authToken with the associated KID.
    */
-  private async _findJWK(kid: string): Promise<JWK | undefined> {
-    if (!AUTH_CACHE) return undefined;
-    try {
-      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-      if (jwk) {
-        return jwk;
-      }
-    } catch (e) {
-      // if there is no JWK, cache might need to be updated; update cache and try again
-      await this.fetchJWKS(true);
-      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-      if (jwk) {
-        return jwk;
-      }
-      return undefined;
+    private async _findJWK(kid: string): Promise<JWK | undefined> {
+        if (!AUTH_CACHE) return undefined;
+        try {
+            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+            if (jwk) {
+                return jwk;
+            }
+        } catch (e) {
+            // if there is no JWK, cache might need to be updated; update cache and try again
+            await this.fetchJWKS(true);
+            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+            if (jwk) {
+                return jwk;
+            }
+            return undefined;
+        }
     }
-  }
 
-  /**
+    /**
    * Determine if the provided token is valid when compared with its
    * respective public key.
    *
    * @param {string} token Authentication token
    * @return {string} sub claim if the jwt can be verified, or undefined
    */
-  async validAuthToken(token: string): Promise<string | undefined> {
-    try {
-      const { kid } = jwt.decode(token, { complete: true })!.header;
-      if (!kid) {
-        return undefined;
-      }
-      const jwk = await this._findJWK(kid);
-      if (!jwk) {
-        return undefined;
-      }
+    async validAuthToken(token: string): Promise<string | undefined> {
+        try {
+            const { kid } = jwt.decode(token, { complete: true })!.header;
+            if (!kid) {
+                return undefined;
+            }
+            const jwk = await this._findJWK(kid);
+            if (!jwk) {
+                return undefined;
+            }
 
-      const pem = jwkToPem(jwk as RSA);
+            const pem = jwkToPem(jwk as RSA);
 
-      const userID = jwt.verify(token, pem, {
-        // @ts-ignore
-        algorithms: jwk.alg,
-      }).sub;
-      if (userID) return userID.toString();
-      else return undefined;
-    } catch (e) {
-      return undefined;
+            const userID = jwt.verify(token, pem, {
+                // @ts-ignore
+                algorithms: jwk.alg,
+            }).sub;
+            if (userID) return userID.toString();
+            else return undefined;
+        } catch (e) {
+            return undefined;
+        }
     }
-  }
 
-  /**
+    /**
    * Create a Magic Link for your app.
    *
    * @param {MagicLinkRequest} magicLinkReq options for creating a MagicLink.
    * @return {Promise<MagicLinkObject>} Passage MagicLink object
    */
-  async createMagicLink(
-    magicLinkReq: MagicLinkRequest
-  ): Promise<MagicLinkObject> {
-    const magicLinkData: MagicLinkObject = await axios
-      .post(
-        `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
-        magicLinkReq,
-        {
-          headers: {
-            Authorization: `Bearer ${this.#apiKey}`,
-          },
-        }
-      )
-      .catch((err) => {
-        throw new Error(
-          `Could not create a magic link for this app. HTTP Status: ${err.response.status}.`
-        );
-      })
-      .then((res) => {
-        return res.data.magic_link;
-      });
-    return magicLinkData;
-  }
+    async createMagicLink(
+        magicLinkReq: MagicLinkRequest
+    ): Promise<MagicLinkObject> {
+        const magicLinkData: MagicLinkObject = await axios
+            .post(
+                `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
+                magicLinkReq,
+                {
+                    headers: {
+                        Authorization: `Bearer ${this.#apiKey}`,
+                    },
+                }
+            )
+            .catch((err) => {
+                throw new Error(
+                    `Could not create a magic link for this app. HTTP Status: ${err.response.status}.`
+                );
+            })
+            .then((res) => {
+                return res.data.magic_link;
+            });
+        return magicLinkData;
+    }
 
-  /**
+    /**
    * Get App Info about an app
    *
    * @return {Promise<AppObject>} Passage App object
    */
-  async getApp(): Promise<AppObject> {
-    const appData: AppObject = await axios
-      .get(`https://api.passage.id/v1/apps/${this.appID}`)
-      .catch((err) => {
-        throw new Error(
-          `Could not fetch user. HTTP status: ${err.response.status}`
-        );
-      })
-      .then((res) => {
-        return res.data.app;
-      });
+    async getApp(): Promise<AppObject> {
+        const appData: AppObject = await axios
+            .get(`https://api.passage.id/v1/apps/${this.appID}`)
+            .catch((err) => {
+                throw new Error(
+                    `Could not fetch user. HTTP status: ${err.response.status}`
+                );
+            })
+            .then((res) => {
+                return res.data.app;
+            });
 
-    return appData;
-  }
+        return appData;
+    }
 }

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -15,29 +15,29 @@ const AUTH_CACHE: AUTHCACHE = {};
  * Passage Class
  */
 export default class Passage {
-    appID: string;
-    #apiKey: string | undefined;
-    authStrategy: AuthStrategy;
-    user: User;
+  appID: string;
+  #apiKey: string | undefined;
+  authStrategy: AuthStrategy;
+  user: User;
 
-    /**
+  /**
    * Initialize a new Passage instance.
    * @param {PassageConfig} config The default config for Passage initialization
    */
-    constructor(config?: PassageConfig) {
-        if (!config?.appID) {
-            throw new Error(
-                "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
-            );
-        }
-        this.appID = config.appID;
-        this.#apiKey = config?.apiKey;
-        this.user = new User(config);
-
-        this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
+  constructor(config?: PassageConfig) {
+    if (!config?.appID) {
+      throw new Error(
+        "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
+      );
     }
+    this.appID = config.appID;
+    this.#apiKey = config?.apiKey;
+    this.user = new User(config);
 
-    /**
+    this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
+  }
+
+  /**
    * Authenticate request with a cookie, or header. If no authentication
    * strategy is given, authenticate the request via cookie (default
    * authentication strategy).
@@ -45,243 +45,239 @@ export default class Passage {
    * @param {Request} req Express request
    * @return {string} UserID of the Passage user
    */
-    async authenticateRequest(req: Request): Promise<string | false> {
-        if (this.authStrategy == "HEADER") {
-            return this.authenticateRequestWithHeader(req);
-        } else {
-            // defaults to cookie
-            return this.authenticateRequestWithCookie(req);
-        }
+  async authenticateRequest(req: Request): Promise<string> {
+    if (this.authStrategy == "HEADER") {
+      return this.authenticateRequestWithHeader(req);
+    } else {
+      return this.authenticateRequestWithCookie(req);
     }
+  }
 
-    /**
+  /**
    * Set API key for this Passage instance
    * @param {string} _apiKey
    */
-    set apiKey(_apiKey) {
-        this.#apiKey = _apiKey;
-    }
+  set apiKey(_apiKey) {
+    this.#apiKey = _apiKey;
+  }
 
-    /**
+  /**
    * Get API key for this Passage instance
    * @return {string | undefined} Passage API Key
    */
-    get apiKey(): string | undefined {
-        return this.#apiKey;
-    }
+  get apiKey(): string | undefined {
+    return this.#apiKey;
+  }
 
-    /**
+  /**
    * Fetch the corresponding JWKS for this app.
    *
    * @param {boolean} resetCache Optional value to specify whether or not the cache should be reset
    * @return {JWKS} JWKS for this app.
    */
-    async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
+  async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
     // use cached value if found
-        if (
-            AUTH_CACHE[this.appID] !== undefined &&
+    if (
+      AUTH_CACHE[this.appID] !== undefined &&
       Object.keys(AUTH_CACHE).length > 0 &&
       !resetCache
-        ) {
-            return AUTH_CACHE[this.appID]["jwks"];
-        }
-
-        const jwks: { [kid: string]: JWK } = await axios
-            .get(
-                `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not fetch appID\'s JWKs. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                const jwks = res.data.keys;
-                const formattedJWKS: JWKS = {};
-
-                // format jwks for cache
-                for (const jwk of jwks) {
-                    formattedJWKS[jwk.kid] = jwk;
-                }
-
-                Object.assign(AUTH_CACHE, {
-                    [this.appID]: { jwks: { ...formattedJWKS } },
-                });
-                return formattedJWKS;
-            });
-
-        return jwks;
+    ) {
+      return AUTH_CACHE[this.appID]["jwks"];
     }
 
-    /**
+    const jwks: { [kid: string]: JWK } = await axios
+      .get(
+        `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
+      )
+      .catch((err) => {
+        throw new Error(
+          `Could not fetch appID\'s JWKs. HTTP status: ${err.response.status}`
+        );
+      })
+      .then((res) => {
+        const jwks = res.data.keys;
+        const formattedJWKS: JWKS = {};
+
+        // format jwks for cache
+        for (const jwk of jwks) {
+          formattedJWKS[jwk.kid] = jwk;
+        }
+
+        Object.assign(AUTH_CACHE, {
+          [this.appID]: { jwks: { ...formattedJWKS } },
+        });
+        return formattedJWKS;
+      });
+
+    return jwks;
+  }
+
+  /**
    * Authenticate a request via the http header.
    *
    * @param {Request} req Express request
    * @return {string} User ID for Passage User
    */
-    async authenticateRequestWithHeader(req: Request): Promise<string | false> {
-        const { authorization } = req.headers;
+  async authenticateRequestWithHeader(req: Request): Promise<string> {
+    const { authorization } = req.headers;
 
-        if (authorization) {
-            const authToken = authorization.split(" ")[1];
-
-            const userID = await this.validAuthToken(authToken);
-            if (userID) {
-                return userID;
-            } else {
-                throw new Error(
-                    "Could not validate header auth token. You must catch this error."
-                );
-            }
-        } else {
-            throw new Error(
-                "Header authorization not found. You must catch this error."
-            );
-        }
+    if (!authorization) {
+      throw new Error(
+        "Header authorization not found. You must catch this error."
+      );
+    } else {
+      const authToken = authorization.split(" ")[1];
+      const userID = await this.validAuthToken(authToken);
+      if (userID) {
+        return userID;
+      } else {
+        throw new Error("Auth token is invalid");
+      }
     }
+  }
 
-    /**
+  /**
    * Authenticate request via cookie.
    *
    * @param {Request} req Express request
    * @return {string} UserID for Passage User
    */
-    async authenticateRequestWithCookie(req: Request): Promise<string | false> {
-        if (!req.headers.cookie) {
-            throw new Error(
-                "Could not find valid cookie for authentication. You must catch this error."
-            );
-        }
-
-        const cookies = {} as { psg_auth_token: string };
-
-        req.headers.cookie?.split(";").forEach((cookie) => {
-            const parts = cookie.match(/(.*?)=(.*)$/);
-            if (parts) {
-                const key = parts[1].trim();
-                const value = parts[2].trim() || "";
-                // @ts-ignore
-                cookies[key] = value;
-            }
-        });
-
-        const passageAuthToken = cookies.psg_auth_token;
-        if (passageAuthToken) {
-            const userID = await this.validAuthToken(passageAuthToken);
-            if (userID) return userID;
-            else {
-                throw new Error(
-                    "Could not validate auth token. You must catch this error."
-                );
-            }
-        } else {
-            throw new Error(
-                "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
-            );
-        }
+  async authenticateRequestWithCookie(req: Request): Promise<string> {
+    if (!req.headers?.cookie) {
+      throw new Error(
+        "Could not find valid cookie for authentication. You must catch this error."
+      );
     }
 
-    /**
+    const cookies = {} as { psg_auth_token: string };
+
+    req.headers.cookie?.split(";").forEach((cookie) => {
+      const parts = cookie.match(/(.*?)=(.*)$/);
+      if (parts) {
+        const key = parts[1].trim();
+        const value = parts[2].trim() || "";
+        // @ts-ignore
+        cookies[key] = value;
+      }
+    });
+
+    const passageAuthToken = cookies.psg_auth_token;
+    if (passageAuthToken) {
+      const userID = await this.validAuthToken(passageAuthToken);
+      if (userID) return userID;
+      else {
+        throw new Error(
+          "Could not validate auth token. You must catch this error."
+        );
+      }
+    } else {
+      throw new Error(
+        "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
+      );
+    }
+  }
+
+  /**
    *
    * @param {string} kid the KID from the authToken to determine which JWK to use.
    * @return {Promise<JWK | undefined>} the JWK to be used for decoding an authToken with the associated KID.
    */
-    private async _findJWK(kid: string): Promise<JWK | undefined> {
-        if (!AUTH_CACHE) return undefined;
-        try {
-            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-            if (jwk) {
-                return jwk;
-            }
-        } catch (e) {
-            // if there is no JWK, cache might need to be updated; update cache and try again
-            await this.fetchJWKS(true);
-            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-            if (jwk) {
-                return jwk;
-            }
-            return undefined;
-        }
+  private async _findJWK(kid: string): Promise<JWK | undefined> {
+    if (!AUTH_CACHE) return undefined;
+    try {
+      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+      if (jwk) {
+        return jwk;
+      }
+    } catch (e) {
+      // if there is no JWK, cache might need to be updated; update cache and try again
+      await this.fetchJWKS(true);
+      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+      if (jwk) {
+        return jwk;
+      }
+      return undefined;
     }
+  }
 
-    /**
+  /**
    * Determine if the provided token is valid when compared with its
    * respective public key.
    *
    * @param {string} token Authentication token
    * @return {string} sub claim if the jwt can be verified, or undefined
    */
-    async validAuthToken(token: string): Promise<string | undefined> {
-        try {
-            const { kid } = jwt.decode(token, { complete: true })!.header;
-            if (!kid) {
-                return undefined;
-            }
-            const jwk = await this._findJWK(kid);
-            if (!jwk) {
-                return undefined;
-            }
+  async validAuthToken(token: string): Promise<string | undefined> {
+    try {
+      const { kid } = jwt.decode(token, { complete: true })!.header;
+      if (!kid) {
+        return undefined;
+      }
+      const jwk = await this._findJWK(kid);
+      if (!jwk) {
+        return undefined;
+      }
 
-            const pem = jwkToPem(jwk as RSA);
+      const pem = jwkToPem(jwk as RSA);
 
-            const userID = jwt.verify(token, pem, {
-                // @ts-ignore
-                algorithms: jwk.alg,
-            }).sub;
-            if (userID) return userID.toString();
-            else return undefined;
-        } catch (e) {
-            return undefined;
-        }
+      const userID = jwt.verify(token, pem, {
+        // @ts-ignore
+        algorithms: jwk.alg,
+      }).sub;
+      if (userID) return userID.toString();
+      else return undefined;
+    } catch (e) {
+      return undefined;
     }
+  }
 
-    /**
+  /**
    * Create a Magic Link for your app.
    *
    * @param {MagicLinkRequest} magicLinkReq options for creating a MagicLink.
    * @return {Promise<MagicLinkObject>} Passage MagicLink object
    */
-    async createMagicLink(
-        magicLinkReq: MagicLinkRequest
-    ): Promise<MagicLinkObject> {
-        const magicLinkData: MagicLinkObject = await axios
-            .post(
-                `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
-                magicLinkReq,
-                {
-                    headers: {
-                        Authorization: `Bearer ${this.#apiKey}`,
-                    },
-                }
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not create a magic link for this app. HTTP Status: ${err.response.status}.`
-                );
-            })
-            .then((res) => {
-                return res.data.magic_link;
-            });
-        return magicLinkData;
-    }
+  async createMagicLink(
+    magicLinkReq: MagicLinkRequest
+  ): Promise<MagicLinkObject> {
+    const magicLinkData: MagicLinkObject = await axios
+      .post(
+        `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
+        magicLinkReq,
+        {
+          headers: {
+            Authorization: `Bearer ${this.#apiKey}`,
+          },
+        }
+      )
+      .catch((err) => {
+        throw new Error(
+          `Could not create a magic link for this app. HTTP Status: ${err.response.status}.`
+        );
+      })
+      .then((res) => {
+        return res.data.magic_link;
+      });
+    return magicLinkData;
+  }
 
-    /**
+  /**
    * Get App Info about an app
    *
    * @return {Promise<AppObject>} Passage App object
    */
-    async getApp(): Promise<AppObject> {
-        const appData: AppObject = await axios
-            .get(`https://api.passage.id/v1/apps/${this.appID}`)
-            .catch((err) => {
-                throw new Error(
-                    `Could not fetch user. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.app;
-            });
+  async getApp(): Promise<AppObject> {
+    const appData: AppObject = await axios
+      .get(`https://api.passage.id/v1/apps/${this.appID}`)
+      .catch((err) => {
+        throw new Error(
+          `Could not fetch user. HTTP status: ${err.response.status}`
+        );
+      })
+      .then((res) => {
+        return res.data.app;
+      });
 
-        return appData;
-    }
+    return appData;
+  }
 }

--- a/src/types/AuthStrategy.ts
+++ b/src/types/AuthStrategy.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 
-export enum AuthStrategyEnum {
+enum AuthStrategyEnum {
   COOKIE = "COOKIE",
   HEADER = "HEADER",
 }

--- a/src/types/AuthStrategy.ts
+++ b/src/types/AuthStrategy.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 
-enum AuthStrategyEnum {
+export enum AuthStrategyEnum {
   COOKIE = "COOKIE",
   HEADER = "HEADER",
 }


### PR DESCRIPTION
**Overview**
This issue was raised in https://github.com/passageidentity/passage-node/issues/40. The `authenticateRequest`, `authenticateRequestWithHeader`, and `authenticateRequestWithCookie` functions had a return type of `Promise<string | false>` when they really only return a string value. 

**Minor Changes**
* Reordered the `authenticateRequestWithHeader` flow to match `authenticateRequestWithCookies`

**Notes**
This PR is best reviewed with whitespace changes off. There are linter updates that provide no functional changes. 