### PR TITLE
PSG-990 propogate api errors up with PassageError class

### DIFF
--- a/change/@passageidentity-passage-node-77996da3-c653-4914-8208-70e757131aa7.json
+++ b/change/@passageidentity-passage-node-77996da3-c653-4914-8208-70e757131aa7.json
@@ -2,6 +2,6 @@
   "type": "minor",
   "comment": "add new PassageError class for handling errors",
   "packageName": "@passageidentity/passage-node",
-  "email": "chrisloper@utexas.edu",
+  "email": "chris.loper@passage.id",
   "dependentChangeType": "patch"
 }

--- a/change/@passageidentity-passage-node-77996da3-c653-4914-8208-70e757131aa7.json
+++ b/change/@passageidentity-passage-node-77996da3-c653-4914-8208-70e757131aa7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add new PassageError class for handling errors",
+  "packageName": "@passageidentity/passage-node",
+  "email": "chrisloper@utexas.edu",
+  "dependentChangeType": "patch"
+}

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -91,7 +91,6 @@ export default class Passage {
                 `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
             )
             .catch((err: AxiosError) => {
-                console.log("error", err);
                 throw new PassageError("Could not fetch appID's JWKs", err);
             })
             .then((res) => {

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -5,9 +5,10 @@ import User from "./User";
 import jwt from "jsonwebtoken";
 import { Request } from "express-serve-static-core";
 import jwkToPem, { RSA } from "jwk-to-pem";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { PassageConfig } from "../types/PassageConfig";
 import { AUTHCACHE, JWK, JWKS } from "../types/JWKS";
+import { PassageError } from "./PassageError";
 
 const AUTH_CACHE: AUTHCACHE = {};
 
@@ -15,29 +16,29 @@ const AUTH_CACHE: AUTHCACHE = {};
  * Passage Class
  */
 export default class Passage {
-    appID: string;
-    #apiKey: string | undefined;
-    authStrategy: AuthStrategy;
-    user: User;
+  appID: string;
+  #apiKey: string | undefined;
+  authStrategy: AuthStrategy;
+  user: User;
 
-    /**
+  /**
    * Initialize a new Passage instance.
    * @param {PassageConfig} config The default config for Passage initialization
    */
-    constructor(config?: PassageConfig) {
-        if (!config?.appID) {
-            throw new Error(
-                "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
-            );
-        }
-        this.appID = config.appID;
-        this.#apiKey = config?.apiKey;
-        this.user = new User(config);
-
-        this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
+  constructor(config?: PassageConfig) {
+    if (!config?.appID) {
+      throw new PassageError(
+        "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
+      );
     }
+    this.appID = config.appID;
+    this.#apiKey = config?.apiKey;
+    this.user = new User(config);
 
-    /**
+    this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
+  }
+
+  /**
    * Authenticate request with a cookie, or header. If no authentication
    * strategy is given, authenticate the request via cookie (default
    * authentication strategy).
@@ -45,239 +46,237 @@ export default class Passage {
    * @param {Request} req Express request
    * @return {string} UserID of the Passage user
    */
-    async authenticateRequest(req: Request): Promise<string> {
-        if (this.authStrategy == "HEADER") {
-            return this.authenticateRequestWithHeader(req);
-        } else {
-            return this.authenticateRequestWithCookie(req);
-        }
+  async authenticateRequest(req: Request): Promise<string> {
+    if (this.authStrategy == "HEADER") {
+      return this.authenticateRequestWithHeader(req);
+    } else {
+      return this.authenticateRequestWithCookie(req);
     }
+  }
 
-    /**
+  /**
    * Set API key for this Passage instance
    * @param {string} _apiKey
    */
-    set apiKey(_apiKey) {
-        this.#apiKey = _apiKey;
-    }
+  set apiKey(_apiKey) {
+    this.#apiKey = _apiKey;
+  }
 
-    /**
+  /**
    * Get API key for this Passage instance
    * @return {string | undefined} Passage API Key
    */
-    get apiKey(): string | undefined {
-        return this.#apiKey;
-    }
+  get apiKey(): string | undefined {
+    return this.#apiKey;
+  }
 
-    /**
+  /**
    * Fetch the corresponding JWKS for this app.
    *
    * @param {boolean} resetCache Optional value to specify whether or not the cache should be reset
    * @return {JWKS} JWKS for this app.
    */
-    async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
+  async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
     // use cached value if found
-        if (
-            AUTH_CACHE[this.appID] !== undefined &&
+    if (
+      AUTH_CACHE[this.appID] !== undefined &&
       Object.keys(AUTH_CACHE).length > 0 &&
       !resetCache
-        ) {
-            return AUTH_CACHE[this.appID]["jwks"];
-        }
-
-        const jwks: { [kid: string]: JWK } = await axios
-            .get(
-                `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not fetch appID\'s JWKs. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                const jwks = res.data.keys;
-                const formattedJWKS: JWKS = {};
-
-                // format jwks for cache
-                for (const jwk of jwks) {
-                    formattedJWKS[jwk.kid] = jwk;
-                }
-
-                Object.assign(AUTH_CACHE, {
-                    [this.appID]: { jwks: { ...formattedJWKS } },
-                });
-                return formattedJWKS;
-            });
-
-        return jwks;
+    ) {
+      return AUTH_CACHE[this.appID]["jwks"];
     }
 
-    /**
+    const jwks: { [kid: string]: JWK } = await axios
+      .get(
+        `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
+      )
+      .catch((err: AxiosError) => {
+        console.log("error", err);
+        throw new PassageError("Could not fetch appID's JWKs", err);
+      })
+      .then((res) => {
+        const jwks = res.data.keys;
+        const formattedJWKS: JWKS = {};
+
+        // format jwks for cache
+        for (const jwk of jwks) {
+          formattedJWKS[jwk.kid] = jwk;
+        }
+
+        Object.assign(AUTH_CACHE, {
+          [this.appID]: { jwks: { ...formattedJWKS } },
+        });
+        return formattedJWKS;
+      });
+
+    return jwks;
+  }
+
+  /**
    * Authenticate a request via the http header.
    *
    * @param {Request} req Express request
    * @return {string} User ID for Passage User
    */
-    async authenticateRequestWithHeader(req: Request): Promise<string> {
-        const { authorization } = req.headers;
+  async authenticateRequestWithHeader(req: Request): Promise<string> {
+    const { authorization } = req.headers;
 
-        if (!authorization) {
-            throw new Error(
-                "Header authorization not found. You must catch this error."
-            );
-        } else {
-            const authToken = authorization.split(" ")[1];
-            const userID = await this.validAuthToken(authToken);
-            if (userID) {
-                return userID;
-            } else {
-                throw new Error("Auth token is invalid");
-            }
-        }
+    if (!authorization) {
+      throw new PassageError(
+        "Header authorization not found. You must catch this error."
+      );
+    } else {
+      const authToken = authorization.split(" ")[1];
+      const userID = await this.validAuthToken(authToken);
+      if (userID) {
+        return userID;
+      } else {
+        throw new Error("Auth token is invalid");
+      }
     }
+  }
 
-    /**
+  /**
    * Authenticate request via cookie.
    *
    * @param {Request} req Express request
    * @return {string} UserID for Passage User
    */
-    async authenticateRequestWithCookie(req: Request): Promise<string> {
-        if (!req.headers?.cookie) {
-            throw new Error(
-                "Could not find valid cookie for authentication. You must catch this error."
-            );
-        }
-
-        const cookies = {} as { psg_auth_token: string };
-
-        req.headers.cookie?.split(";").forEach((cookie) => {
-            const parts = cookie.match(/(.*?)=(.*)$/);
-            if (parts) {
-                const key = parts[1].trim();
-                const value = parts[2].trim() || "";
-                // @ts-ignore
-                cookies[key] = value;
-            }
-        });
-
-        const passageAuthToken = cookies.psg_auth_token;
-        if (passageAuthToken) {
-            const userID = await this.validAuthToken(passageAuthToken);
-            if (userID) return userID;
-            else {
-                throw new Error(
-                    "Could not validate auth token. You must catch this error."
-                );
-            }
-        } else {
-            throw new Error(
-                "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
-            );
-        }
+  async authenticateRequestWithCookie(req: Request): Promise<string> {
+    if (!req.headers?.cookie) {
+      throw new PassageError(
+        "Could not find valid cookie for authentication. You must catch this error."
+      );
     }
 
-    /**
+    const cookies = {} as { psg_auth_token: string };
+
+    req.headers.cookie?.split(";").forEach((cookie) => {
+      const parts = cookie.match(/(.*?)=(.*)$/);
+      if (parts) {
+        const key = parts[1].trim();
+        const value = parts[2].trim() || "";
+        // @ts-ignore
+        cookies[key] = value;
+      }
+    });
+
+    const passageAuthToken = cookies.psg_auth_token;
+    if (passageAuthToken) {
+      const userID = await this.validAuthToken(passageAuthToken);
+      if (userID) return userID;
+      else {
+        throw new PassageError(
+          "Could not validate auth token. You must catch this error."
+        );
+      }
+    } else {
+      throw new PassageError(
+        "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
+      );
+    }
+  }
+
+  /**
    *
    * @param {string} kid the KID from the authToken to determine which JWK to use.
    * @return {Promise<JWK | undefined>} the JWK to be used for decoding an authToken with the associated KID.
    */
-    private async _findJWK(kid: string): Promise<JWK | undefined> {
-        if (!AUTH_CACHE) return undefined;
-        try {
-            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-            if (jwk) {
-                return jwk;
-            }
-        } catch (e) {
-            // if there is no JWK, cache might need to be updated; update cache and try again
-            await this.fetchJWKS(true);
-            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-            if (jwk) {
-                return jwk;
-            }
-            return undefined;
-        }
+  private async _findJWK(kid: string): Promise<JWK | undefined> {
+    if (!AUTH_CACHE) return undefined;
+    try {
+      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+      if (jwk) {
+        return jwk;
+      }
+    } catch (e) {
+      // if there is no JWK, cache might need to be updated; update cache and try again
+      await this.fetchJWKS(true);
+      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+      if (jwk) {
+        return jwk;
+      }
+      return undefined;
     }
+  }
 
-    /**
+  /**
    * Determine if the provided token is valid when compared with its
    * respective public key.
    *
    * @param {string} token Authentication token
    * @return {string} sub claim if the jwt can be verified, or undefined
    */
-    async validAuthToken(token: string): Promise<string | undefined> {
-        try {
-            const { kid } = jwt.decode(token, { complete: true })!.header;
-            if (!kid) {
-                return undefined;
-            }
-            const jwk = await this._findJWK(kid);
-            if (!jwk) {
-                return undefined;
-            }
+  async validAuthToken(token: string): Promise<string | undefined> {
+    try {
+      const { kid } = jwt.decode(token, { complete: true })!.header;
+      if (!kid) {
+        return undefined;
+      }
+      const jwk = await this._findJWK(kid);
+      if (!jwk) {
+        return undefined;
+      }
 
-            const pem = jwkToPem(jwk as RSA);
+      const pem = jwkToPem(jwk as RSA);
 
-            const userID = jwt.verify(token, pem, {
-                // @ts-ignore
-                algorithms: jwk.alg,
-            }).sub;
-            if (userID) return userID.toString();
-            else return undefined;
-        } catch (e) {
-            return undefined;
-        }
+      const userID = jwt.verify(token, pem, {
+        // @ts-ignore
+        algorithms: jwk.alg,
+      }).sub;
+      if (userID) return userID.toString();
+      else return undefined;
+    } catch (e) {
+      return undefined;
     }
+  }
 
-    /**
+  /**
    * Create a Magic Link for your app.
    *
    * @param {MagicLinkRequest} magicLinkReq options for creating a MagicLink.
    * @return {Promise<MagicLinkObject>} Passage MagicLink object
    */
-    async createMagicLink(
-        magicLinkReq: MagicLinkRequest
-    ): Promise<MagicLinkObject> {
-        const magicLinkData: MagicLinkObject = await axios
-            .post(
-                `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
-                magicLinkReq,
-                {
-                    headers: {
-                        Authorization: `Bearer ${this.#apiKey}`,
-                    },
-                }
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not create a magic link for this app. HTTP Status: ${err.response.status}.`
-                );
-            })
-            .then((res) => {
-                return res.data.magic_link;
-            });
-        return magicLinkData;
-    }
+  async createMagicLink(
+    magicLinkReq: MagicLinkRequest
+  ): Promise<MagicLinkObject> {
+    const magicLinkData: MagicLinkObject = await axios
+      .post(
+        `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
+        magicLinkReq,
+        {
+          headers: {
+            Authorization: `Bearer ${this.#apiKey}`,
+          },
+        }
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError(
+          "Could not create a magic link for this app.",
+          err
+        );
+      })
+      .then((res) => {
+        return res.data.magic_link;
+      });
+    return magicLinkData;
+  }
 
-    /**
+  /**
    * Get App Info about an app
    *
    * @return {Promise<AppObject>} Passage App object
    */
-    async getApp(): Promise<AppObject> {
-        const appData: AppObject = await axios
-            .get(`https://api.passage.id/v1/apps/${this.appID}`)
-            .catch((err) => {
-                throw new Error(
-                    `Could not fetch user. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.app;
-            });
+  async getApp(): Promise<AppObject> {
+    const appData: AppObject = await axios
+      .get(`https://api.passage.id/v1/apps/${this.appID}`)
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not fetch app.", err);
+      })
+      .then((res) => {
+        return res.data.app;
+      });
 
-        return appData;
-    }
+    return appData;
+  }
 }

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -16,29 +16,29 @@ const AUTH_CACHE: AUTHCACHE = {};
  * Passage Class
  */
 export default class Passage {
-  appID: string;
-  #apiKey: string | undefined;
-  authStrategy: AuthStrategy;
-  user: User;
+    appID: string;
+    #apiKey: string | undefined;
+    authStrategy: AuthStrategy;
+    user: User;
 
-  /**
+    /**
    * Initialize a new Passage instance.
    * @param {PassageConfig} config The default config for Passage initialization
    */
-  constructor(config?: PassageConfig) {
-    if (!config?.appID) {
-      throw new PassageError(
-        "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
-      );
+    constructor(config?: PassageConfig) {
+        if (!config?.appID) {
+            throw new PassageError(
+                "A Passage appID is required. Please include {appID: YOUR_APP_ID}."
+            );
+        }
+        this.appID = config.appID;
+        this.#apiKey = config?.apiKey;
+        this.user = new User(config);
+
+        this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
     }
-    this.appID = config.appID;
-    this.#apiKey = config?.apiKey;
-    this.user = new User(config);
 
-    this.authStrategy = config?.authStrategy ? config.authStrategy : "COOKIE";
-  }
-
-  /**
+    /**
    * Authenticate request with a cookie, or header. If no authentication
    * strategy is given, authenticate the request via cookie (default
    * authentication strategy).
@@ -46,237 +46,237 @@ export default class Passage {
    * @param {Request} req Express request
    * @return {string} UserID of the Passage user
    */
-  async authenticateRequest(req: Request): Promise<string> {
-    if (this.authStrategy == "HEADER") {
-      return this.authenticateRequestWithHeader(req);
-    } else {
-      return this.authenticateRequestWithCookie(req);
+    async authenticateRequest(req: Request): Promise<string> {
+        if (this.authStrategy == "HEADER") {
+            return this.authenticateRequestWithHeader(req);
+        } else {
+            return this.authenticateRequestWithCookie(req);
+        }
     }
-  }
 
-  /**
+    /**
    * Set API key for this Passage instance
    * @param {string} _apiKey
    */
-  set apiKey(_apiKey) {
-    this.#apiKey = _apiKey;
-  }
+    set apiKey(_apiKey) {
+        this.#apiKey = _apiKey;
+    }
 
-  /**
+    /**
    * Get API key for this Passage instance
    * @return {string | undefined} Passage API Key
    */
-  get apiKey(): string | undefined {
-    return this.#apiKey;
-  }
+    get apiKey(): string | undefined {
+        return this.#apiKey;
+    }
 
-  /**
+    /**
    * Fetch the corresponding JWKS for this app.
    *
    * @param {boolean} resetCache Optional value to specify whether or not the cache should be reset
    * @return {JWKS} JWKS for this app.
    */
-  async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
+    async fetchJWKS(resetCache?: boolean): Promise<JWKS> {
     // use cached value if found
-    if (
-      AUTH_CACHE[this.appID] !== undefined &&
+        if (
+            AUTH_CACHE[this.appID] !== undefined &&
       Object.keys(AUTH_CACHE).length > 0 &&
       !resetCache
-    ) {
-      return AUTH_CACHE[this.appID]["jwks"];
-    }
-
-    const jwks: { [kid: string]: JWK } = await axios
-      .get(
-        `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
-      )
-      .catch((err: AxiosError) => {
-        console.log("error", err);
-        throw new PassageError("Could not fetch appID's JWKs", err);
-      })
-      .then((res) => {
-        const jwks = res.data.keys;
-        const formattedJWKS: JWKS = {};
-
-        // format jwks for cache
-        for (const jwk of jwks) {
-          formattedJWKS[jwk.kid] = jwk;
+        ) {
+            return AUTH_CACHE[this.appID]["jwks"];
         }
 
-        Object.assign(AUTH_CACHE, {
-          [this.appID]: { jwks: { ...formattedJWKS } },
-        });
-        return formattedJWKS;
-      });
+        const jwks: { [kid: string]: JWK } = await axios
+            .get(
+                `https://auth.passage.id/v1/apps/${this.appID}/.well-known/jwks.json`
+            )
+            .catch((err: AxiosError) => {
+                console.log("error", err);
+                throw new PassageError("Could not fetch appID's JWKs", err);
+            })
+            .then((res) => {
+                const jwks = res.data.keys;
+                const formattedJWKS: JWKS = {};
 
-    return jwks;
-  }
+                // format jwks for cache
+                for (const jwk of jwks) {
+                    formattedJWKS[jwk.kid] = jwk;
+                }
 
-  /**
+                Object.assign(AUTH_CACHE, {
+                    [this.appID]: { jwks: { ...formattedJWKS } },
+                });
+                return formattedJWKS;
+            });
+
+        return jwks;
+    }
+
+    /**
    * Authenticate a request via the http header.
    *
    * @param {Request} req Express request
    * @return {string} User ID for Passage User
    */
-  async authenticateRequestWithHeader(req: Request): Promise<string> {
-    const { authorization } = req.headers;
+    async authenticateRequestWithHeader(req: Request): Promise<string> {
+        const { authorization } = req.headers;
 
-    if (!authorization) {
-      throw new PassageError(
-        "Header authorization not found. You must catch this error."
-      );
-    } else {
-      const authToken = authorization.split(" ")[1];
-      const userID = await this.validAuthToken(authToken);
-      if (userID) {
-        return userID;
-      } else {
-        throw new Error("Auth token is invalid");
-      }
+        if (!authorization) {
+            throw new PassageError(
+                "Header authorization not found. You must catch this error."
+            );
+        } else {
+            const authToken = authorization.split(" ")[1];
+            const userID = await this.validAuthToken(authToken);
+            if (userID) {
+                return userID;
+            } else {
+                throw new Error("Auth token is invalid");
+            }
+        }
     }
-  }
 
-  /**
+    /**
    * Authenticate request via cookie.
    *
    * @param {Request} req Express request
    * @return {string} UserID for Passage User
    */
-  async authenticateRequestWithCookie(req: Request): Promise<string> {
-    if (!req.headers?.cookie) {
-      throw new PassageError(
-        "Could not find valid cookie for authentication. You must catch this error."
-      );
+    async authenticateRequestWithCookie(req: Request): Promise<string> {
+        if (!req.headers?.cookie) {
+            throw new PassageError(
+                "Could not find valid cookie for authentication. You must catch this error."
+            );
+        }
+
+        const cookies = {} as { psg_auth_token: string };
+
+        req.headers.cookie?.split(";").forEach((cookie) => {
+            const parts = cookie.match(/(.*?)=(.*)$/);
+            if (parts) {
+                const key = parts[1].trim();
+                const value = parts[2].trim() || "";
+                // @ts-ignore
+                cookies[key] = value;
+            }
+        });
+
+        const passageAuthToken = cookies.psg_auth_token;
+        if (passageAuthToken) {
+            const userID = await this.validAuthToken(passageAuthToken);
+            if (userID) return userID;
+            else {
+                throw new PassageError(
+                    "Could not validate auth token. You must catch this error."
+                );
+            }
+        } else {
+            throw new PassageError(
+                "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
+            );
+        }
     }
 
-    const cookies = {} as { psg_auth_token: string };
-
-    req.headers.cookie?.split(";").forEach((cookie) => {
-      const parts = cookie.match(/(.*?)=(.*)$/);
-      if (parts) {
-        const key = parts[1].trim();
-        const value = parts[2].trim() || "";
-        // @ts-ignore
-        cookies[key] = value;
-      }
-    });
-
-    const passageAuthToken = cookies.psg_auth_token;
-    if (passageAuthToken) {
-      const userID = await this.validAuthToken(passageAuthToken);
-      if (userID) return userID;
-      else {
-        throw new PassageError(
-          "Could not validate auth token. You must catch this error."
-        );
-      }
-    } else {
-      throw new PassageError(
-        "Could not find authentication cookie 'psg_auth_token' token. You must catch this error."
-      );
-    }
-  }
-
-  /**
+    /**
    *
    * @param {string} kid the KID from the authToken to determine which JWK to use.
    * @return {Promise<JWK | undefined>} the JWK to be used for decoding an authToken with the associated KID.
    */
-  private async _findJWK(kid: string): Promise<JWK | undefined> {
-    if (!AUTH_CACHE) return undefined;
-    try {
-      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-      if (jwk) {
-        return jwk;
-      }
-    } catch (e) {
-      // if there is no JWK, cache might need to be updated; update cache and try again
-      await this.fetchJWKS(true);
-      const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
-      if (jwk) {
-        return jwk;
-      }
-      return undefined;
+    private async _findJWK(kid: string): Promise<JWK | undefined> {
+        if (!AUTH_CACHE) return undefined;
+        try {
+            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+            if (jwk) {
+                return jwk;
+            }
+        } catch (e) {
+            // if there is no JWK, cache might need to be updated; update cache and try again
+            await this.fetchJWKS(true);
+            const jwk = AUTH_CACHE[this.appID]["jwks"][kid];
+            if (jwk) {
+                return jwk;
+            }
+            return undefined;
+        }
     }
-  }
 
-  /**
+    /**
    * Determine if the provided token is valid when compared with its
    * respective public key.
    *
    * @param {string} token Authentication token
    * @return {string} sub claim if the jwt can be verified, or undefined
    */
-  async validAuthToken(token: string): Promise<string | undefined> {
-    try {
-      const { kid } = jwt.decode(token, { complete: true })!.header;
-      if (!kid) {
-        return undefined;
-      }
-      const jwk = await this._findJWK(kid);
-      if (!jwk) {
-        return undefined;
-      }
+    async validAuthToken(token: string): Promise<string | undefined> {
+        try {
+            const { kid } = jwt.decode(token, { complete: true })!.header;
+            if (!kid) {
+                return undefined;
+            }
+            const jwk = await this._findJWK(kid);
+            if (!jwk) {
+                return undefined;
+            }
 
-      const pem = jwkToPem(jwk as RSA);
+            const pem = jwkToPem(jwk as RSA);
 
-      const userID = jwt.verify(token, pem, {
-        // @ts-ignore
-        algorithms: jwk.alg,
-      }).sub;
-      if (userID) return userID.toString();
-      else return undefined;
-    } catch (e) {
-      return undefined;
+            const userID = jwt.verify(token, pem, {
+                // @ts-ignore
+                algorithms: jwk.alg,
+            }).sub;
+            if (userID) return userID.toString();
+            else return undefined;
+        } catch (e) {
+            return undefined;
+        }
     }
-  }
 
-  /**
+    /**
    * Create a Magic Link for your app.
    *
    * @param {MagicLinkRequest} magicLinkReq options for creating a MagicLink.
    * @return {Promise<MagicLinkObject>} Passage MagicLink object
    */
-  async createMagicLink(
-    magicLinkReq: MagicLinkRequest
-  ): Promise<MagicLinkObject> {
-    const magicLinkData: MagicLinkObject = await axios
-      .post(
-        `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
-        magicLinkReq,
-        {
-          headers: {
-            Authorization: `Bearer ${this.#apiKey}`,
-          },
-        }
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError(
-          "Could not create a magic link for this app.",
-          err
-        );
-      })
-      .then((res) => {
-        return res.data.magic_link;
-      });
-    return magicLinkData;
-  }
+    async createMagicLink(
+        magicLinkReq: MagicLinkRequest
+    ): Promise<MagicLinkObject> {
+        const magicLinkData: MagicLinkObject = await axios
+            .post(
+                `https://api.passage.id/v1/apps/${this.appID}/magic-links/`,
+                magicLinkReq,
+                {
+                    headers: {
+                        Authorization: `Bearer ${this.#apiKey}`,
+                    },
+                }
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError(
+                    "Could not create a magic link for this app.",
+                    err
+                );
+            })
+            .then((res) => {
+                return res.data.magic_link;
+            });
+        return magicLinkData;
+    }
 
-  /**
+    /**
    * Get App Info about an app
    *
    * @return {Promise<AppObject>} Passage App object
    */
-  async getApp(): Promise<AppObject> {
-    const appData: AppObject = await axios
-      .get(`https://api.passage.id/v1/apps/${this.appID}`)
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not fetch app.", err);
-      })
-      .then((res) => {
-        return res.data.app;
-      });
+    async getApp(): Promise<AppObject> {
+        const appData: AppObject = await axios
+            .get(`https://api.passage.id/v1/apps/${this.appID}`)
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not fetch app.", err);
+            })
+            .then((res) => {
+                return res.data.app;
+            });
 
-    return appData;
-  }
+        return appData;
+    }
 }

--- a/src/classes/PassageError.ts
+++ b/src/classes/PassageError.ts
@@ -4,22 +4,22 @@ import { AxiosError } from "axios";
  * Passage Class
  */
 export class PassageError extends Error {
-  readonly statusCode: number | undefined;
-  readonly statusText: string | undefined;
-  readonly error: string | undefined;
-  readonly message: string;
+    readonly statusCode: number | undefined;
+    readonly statusText: string | undefined;
+    readonly error: string | undefined;
+    readonly message: string;
 
-  /**
+    /**
    * Initialize a new PassageError instance.
    * @param {string} message friendly message,
    * @param {AxiosError} err error from axios request
    */
-  constructor(message: string, err?: AxiosError) {
-    super();
+    constructor(message: string, err?: AxiosError) {
+        super();
 
-    this.message = message;
-    this.statusCode = err?.response?.status;
-    this.statusText = err?.response?.statusText;
-    this.error = err?.response?.data.error;
-  }
+        this.message = message;
+        this.statusCode = err?.response?.status;
+        this.statusText = err?.response?.statusText;
+        this.error = err?.response?.data.error;
+    }
 }

--- a/src/classes/PassageError.ts
+++ b/src/classes/PassageError.ts
@@ -1,0 +1,25 @@
+import { AxiosError } from "axios";
+
+/**
+ * Passage Class
+ */
+export class PassageError extends Error {
+  readonly statusCode: number | undefined;
+  readonly statusText: string | undefined;
+  readonly error: string | undefined;
+  readonly message: string;
+
+  /**
+   * Initialize a new PassageError instance.
+   * @param {string} message friendly message,
+   * @param {AxiosError} err error from axios request
+   */
+  constructor(message: string, err?: AxiosError) {
+    super();
+
+    this.message = message;
+    this.statusCode = err?.response?.status;
+    this.statusText = err?.response?.statusText;
+    this.error = err?.response?.data.error;
+  }
+}

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import { PassageConfig } from "../types/PassageConfig";
-import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { AxiosError } from "axios";
 import { PassageError } from "./PassageError";
 
 interface UserEventInfo {

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -200,7 +200,7 @@ export default class User {
                 null, // note that this null is required as axios.patch has different param order than axios.get
                 this.#authorizationHeader
             )
-            .catch((err) => {
+            .catch((err: AxiosError) => {
                 throw new PassageError("Could not activate user", err);
             })
             .then((res) => {

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { PassageConfig } from "../types/PassageConfig";
-import axios from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import { PassageError } from "./PassageError";
 
 interface UserEventInfo {
   type: string;
@@ -71,301 +72,271 @@ interface CreateUserPayload {
 
 /***/
 export default class User {
-    #appID: string;
-    #apiKey: string;
-    #authorizationHeader: object | undefined;
-    id: string;
+  #appID: string;
+  #apiKey: string;
+  #authorizationHeader: object | undefined;
+  id: string;
 
-    /**
+  /**
    * Initialize a new Passage User instance.
    *
    * @param {PassageConfig} config The default config for Passage and User initialization
    */
-    constructor(config: PassageConfig) {
-        this.#appID = config.appID ? config.appID : "";
-        this.#apiKey = config.apiKey ? config.apiKey : "";
-        this.id = "";
+  constructor(config: PassageConfig) {
+    this.#appID = config.appID ? config.appID : "";
+    this.#apiKey = config.apiKey ? config.apiKey : "";
+    this.id = "";
 
-        if (this.#apiKey) {
-            this.#authorizationHeader = {
-                headers: {
-                    Authorization: `Bearer ${this.#apiKey}`,
-                },
-            };
-        } else {
-            this.#authorizationHeader = undefined;
-        }
+    if (this.#apiKey) {
+      this.#authorizationHeader = {
+        headers: {
+          Authorization: `Bearer ${this.#apiKey}`,
+        },
+      };
+    } else {
+      this.#authorizationHeader = undefined;
     }
+  }
 
-    /**
+  /**
    * Get a user's object using their user ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<UserObject>} Passage User object
    */
-    async get(userID: string): Promise<UserObject> {
-        if (!this.#apiKey) {
-            throw new Error("A Passage API key is needed to make a getUser request");
-        }
-
-        const userData: UserObject = await axios
-            .get(
-                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not fetch user. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.user;
-            });
-
-        return userData;
+  async get(userID: string): Promise<UserObject> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed.");
     }
 
-    /**
+    const userData: UserObject = await axios
+      .get(
+        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not fetch user.", err);
+      })
+      .then((res) => {
+        return res.data.user;
+      });
+
+    return userData;
+  }
+
+  /**
    * Deactivate a user using their user ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<UserObject>} Passage User object
    */
-    async deactivate(userID: string): Promise<UserObject> {
-        if (!this.#apiKey) {
-            throw new Error(
-                "A Passage API key is needed to make a deactivateUser request"
-            );
-        }
-        const userData: UserObject = await axios
-            .patch(
-                `https://api.passage.id/v1/apps/${
-                    this.#appID
-                }/users/${userID}/deactivate`,
-                null, // note that this null is required as axios.patch has different param order than axios.get
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not deactivate user. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.user;
-            });
-
-        return userData;
+  async deactivate(userID: string): Promise<UserObject> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed.");
     }
+    const userData: UserObject = await axios
+      .patch(
+        `https://api.passage.id/v1/apps/${
+          this.#appID
+        }/users/${userID}/deactivate`,
+        null, // note that this null is required as axios.patch has different param order than axios.get
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not deactivate user.", err);
+      })
+      .then((res) => {
+        return res.data.user;
+      });
 
-    /**
+    return userData;
+  }
+
+  /**
    * Update a user.
    *
    * @param {string} userID The passage user ID
    * @param {UpdateUserPayload} payload The user attributes to be updated
    * @return {Promise<UserObject>} Pasasge User Object
    */
-    async update(
-        userID: string,
-        payload: UpdateUserPayload
-    ): Promise<UserObject> {
-        if (!this.#apiKey) {
-            throw new Error(
-                "A Passage API key is needed to make a user update request"
-            );
-        }
-        const userData: UserObject = await axios
-            .patch(
-                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
-                payload,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not update user attributes (${Object.keys(payload).join(
-                        ", "
-                    )}). HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.user;
-            });
-
-        return userData;
+  async update(
+    userID: string,
+    payload: UpdateUserPayload
+  ): Promise<UserObject> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed.");
     }
+    const userData: UserObject = await axios
+      .patch(
+        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
+        payload,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not update user.", err);
+      })
+      .then((res) => {
+        return res.data.user;
+      });
 
-    /**
+    return userData;
+  }
+
+  /**
    * Activate a user using their user ID.
    *
    * @param {string} userID The passage user ID
    * @return {Promise<UserObject>} Passage User object
    */
-    async activate(userID: string): Promise<UserObject> {
-        if (!this.#apiKey) {
-            throw new Error(
-                "A Passage API key is needed to make an activateUser request"
-            );
-        }
-        const userData: UserObject = await axios
-            .patch(
-                `https://api.passage.id/v1/apps/${
-                    this.#appID
-                }/users/${userID}/activate`,
-                null, // note that this null is required as axios.patch has different param order than axios.get
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not activate user. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.user;
-            });
-
-        return userData;
+  async activate(userID: string): Promise<UserObject> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed");
     }
+    const userData: UserObject = await axios
+      .patch(
+        `https://api.passage.id/v1/apps/${
+          this.#appID
+        }/users/${userID}/activate`,
+        null, // note that this null is required as axios.patch has different param order than axios.get
+        this.#authorizationHeader
+      )
+      .catch((err) => {
+        throw new PassageError("Could not activate user", err);
+      })
+      .then((res) => {
+        return res.data.user;
+      });
 
-    /**
+    return userData;
+  }
+
+  /**
    * Create a user.
    *
    * @param {CreateUserPayload} payload To create the user.
    * @return {Promise<UserObject>} Passage User object
    */
-    async create(payload: CreateUserPayload): Promise<UserObject> {
-        if (!this.#apiKey) {
-            throw new Error(
-                "A Passage API key is needed to make an createUser request"
-            );
-        }
-        const userData: UserObject = await axios
-            .post(
-                `https://api.passage.id/v1/apps/${this.#appID}/users/`,
-                payload,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not create user. HTTP Status: ${err.response.status}.`
-                );
-            })
-            .then((res) => {
-                return res.data.user;
-            });
-        return userData;
+  async create(payload: CreateUserPayload): Promise<UserObject> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed");
     }
+    const userData: UserObject = await axios
+      .post(
+        `https://api.passage.id/v1/apps/${this.#appID}/users/`,
+        payload,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not create user", err);
+      })
+      .then((res) => {
+        return res.data.user;
+      });
+    return userData;
+  }
 
-    /**
+  /**
    * Delete a user using their user ID.
    *
    * @param {string} userID The userID used to delete the corresponding user.
    * Either an E164 phone number or email address.
    * @return {boolean} True if user was deleted, false if not
    */
-    async delete(userID: string): Promise<boolean> {
-        if (!this.#apiKey) {
-            throw new Error(
-                "A Passage API key is needed to make an activateUser request"
-            );
-        }
-        const response: number = await axios
-            .delete(
-                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not delete user with the userID: ${userID}. HTTP Status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.status.valueOf();
-            });
-
-        return response === 200;
+  async delete(userID: string): Promise<boolean> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed");
     }
+    const response: number = await axios
+      .delete(
+        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not delete user.", err);
+      })
+      .then((res) => {
+        return res.status.valueOf();
+      });
 
-    /**
+    return response === 200;
+  }
+
+  /**
    * Get a user's devices using their user ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<Array<WebAuthnDevices>>} List of devices
    */
-    async listDevices(userID: string): Promise<Array<WebAuthnDevices>> {
-        if (!this.#apiKey) {
-            throw new Error("A Passage API key is needed to make a getUser request");
-        }
-
-        const devices: Array<WebAuthnDevices> = await axios
-            .get(
-                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/devices`,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not fetch user's devices. HTTP status: ${err.response.status}`
-                );
-            })
-            .then((res) => {
-                return res.data.devices;
-            });
-
-        return devices;
+  async listDevices(userID: string): Promise<Array<WebAuthnDevices>> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed");
     }
 
-    /**
+    const devices: Array<WebAuthnDevices> = await axios
+      .get(
+        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/devices`,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not fetch user's devices.", err);
+      })
+      .then((res) => {
+        return res.data.devices;
+      });
+
+    return devices;
+  }
+
+  /**
    * Revoke a user's device using their user ID and the device ID.
    *
    * @param {string} userID The Passage user ID
    * @param {string} deviceID The Passage user's device ID
    * @return {Promise<boolean>}
    */
-    async revokeDevice(userID: string, deviceID: string): Promise<boolean> {
-        if (!this.#apiKey) {
-            throw new Error("A Passage API key is needed to make a getUser request");
-        }
-
-        const success: boolean = await axios
-            .delete(
-                `https://api.passage.id/v1/apps/${
-                    this.#appID
-                }/users/${userID}/devices/${deviceID}`,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not delete user device. HTTP status: ${err.response.status}`
-                );
-            })
-            .then(() => {
-                return true;
-            });
-
-        return success;
+  async revokeDevice(userID: string, deviceID: string): Promise<boolean> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed");
     }
 
-    /**
+    const success: boolean = await axios
+      .delete(
+        `https://api.passage.id/v1/apps/${
+          this.#appID
+        }/users/${userID}/devices/${deviceID}`,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not delete user's device", err);
+      })
+      .then(() => {
+        return true;
+      });
+
+    return success;
+  }
+
+  /**
    * Revokes all of a user's Refresh Tokens using their User ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<boolean>}
    */
-    async signOut(userID: string): Promise<boolean> {
-        if (!this.#apiKey) {
-            throw new Error("A Passage API key is needed to make a getUser request");
-        }
-
-        return axios
-            .delete(
-                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/tokens/`,
-                this.#authorizationHeader
-            )
-            .catch((err) => {
-                throw new Error(
-                    `Could not revoke user's refresh tokens. HTTP status: ${err.response.status}`
-                );
-            })
-            .then(() => {
-                return true;
-            });
+  async signOut(userID: string): Promise<boolean> {
+    if (!this.#apiKey) {
+      throw new PassageError("A Passage API key is needed");
     }
+
+    return axios
+      .delete(
+        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/tokens/`,
+        this.#authorizationHeader
+      )
+      .catch((err: AxiosError) => {
+        throw new PassageError("Could not revoke user's refresh tokens.", err);
+      })
+      .then(() => {
+        return true;
+      });
+  }
 }

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -72,271 +72,271 @@ interface CreateUserPayload {
 
 /***/
 export default class User {
-  #appID: string;
-  #apiKey: string;
-  #authorizationHeader: object | undefined;
-  id: string;
+    #appID: string;
+    #apiKey: string;
+    #authorizationHeader: object | undefined;
+    id: string;
 
-  /**
+    /**
    * Initialize a new Passage User instance.
    *
    * @param {PassageConfig} config The default config for Passage and User initialization
    */
-  constructor(config: PassageConfig) {
-    this.#appID = config.appID ? config.appID : "";
-    this.#apiKey = config.apiKey ? config.apiKey : "";
-    this.id = "";
+    constructor(config: PassageConfig) {
+        this.#appID = config.appID ? config.appID : "";
+        this.#apiKey = config.apiKey ? config.apiKey : "";
+        this.id = "";
 
-    if (this.#apiKey) {
-      this.#authorizationHeader = {
-        headers: {
-          Authorization: `Bearer ${this.#apiKey}`,
-        },
-      };
-    } else {
-      this.#authorizationHeader = undefined;
+        if (this.#apiKey) {
+            this.#authorizationHeader = {
+                headers: {
+                    Authorization: `Bearer ${this.#apiKey}`,
+                },
+            };
+        } else {
+            this.#authorizationHeader = undefined;
+        }
     }
-  }
 
-  /**
+    /**
    * Get a user's object using their user ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<UserObject>} Passage User object
    */
-  async get(userID: string): Promise<UserObject> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed.");
+    async get(userID: string): Promise<UserObject> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed.");
+        }
+
+        const userData: UserObject = await axios
+            .get(
+                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not fetch user.", err);
+            })
+            .then((res) => {
+                return res.data.user;
+            });
+
+        return userData;
     }
 
-    const userData: UserObject = await axios
-      .get(
-        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not fetch user.", err);
-      })
-      .then((res) => {
-        return res.data.user;
-      });
-
-    return userData;
-  }
-
-  /**
+    /**
    * Deactivate a user using their user ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<UserObject>} Passage User object
    */
-  async deactivate(userID: string): Promise<UserObject> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed.");
+    async deactivate(userID: string): Promise<UserObject> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed.");
+        }
+        const userData: UserObject = await axios
+            .patch(
+                `https://api.passage.id/v1/apps/${
+                    this.#appID
+                }/users/${userID}/deactivate`,
+                null, // note that this null is required as axios.patch has different param order than axios.get
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not deactivate user.", err);
+            })
+            .then((res) => {
+                return res.data.user;
+            });
+
+        return userData;
     }
-    const userData: UserObject = await axios
-      .patch(
-        `https://api.passage.id/v1/apps/${
-          this.#appID
-        }/users/${userID}/deactivate`,
-        null, // note that this null is required as axios.patch has different param order than axios.get
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not deactivate user.", err);
-      })
-      .then((res) => {
-        return res.data.user;
-      });
 
-    return userData;
-  }
-
-  /**
+    /**
    * Update a user.
    *
    * @param {string} userID The passage user ID
    * @param {UpdateUserPayload} payload The user attributes to be updated
    * @return {Promise<UserObject>} Pasasge User Object
    */
-  async update(
-    userID: string,
-    payload: UpdateUserPayload
-  ): Promise<UserObject> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed.");
+    async update(
+        userID: string,
+        payload: UpdateUserPayload
+    ): Promise<UserObject> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed.");
+        }
+        const userData: UserObject = await axios
+            .patch(
+                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
+                payload,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not update user.", err);
+            })
+            .then((res) => {
+                return res.data.user;
+            });
+
+        return userData;
     }
-    const userData: UserObject = await axios
-      .patch(
-        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
-        payload,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not update user.", err);
-      })
-      .then((res) => {
-        return res.data.user;
-      });
 
-    return userData;
-  }
-
-  /**
+    /**
    * Activate a user using their user ID.
    *
    * @param {string} userID The passage user ID
    * @return {Promise<UserObject>} Passage User object
    */
-  async activate(userID: string): Promise<UserObject> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed");
+    async activate(userID: string): Promise<UserObject> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed");
+        }
+        const userData: UserObject = await axios
+            .patch(
+                `https://api.passage.id/v1/apps/${
+                    this.#appID
+                }/users/${userID}/activate`,
+                null, // note that this null is required as axios.patch has different param order than axios.get
+                this.#authorizationHeader
+            )
+            .catch((err) => {
+                throw new PassageError("Could not activate user", err);
+            })
+            .then((res) => {
+                return res.data.user;
+            });
+
+        return userData;
     }
-    const userData: UserObject = await axios
-      .patch(
-        `https://api.passage.id/v1/apps/${
-          this.#appID
-        }/users/${userID}/activate`,
-        null, // note that this null is required as axios.patch has different param order than axios.get
-        this.#authorizationHeader
-      )
-      .catch((err) => {
-        throw new PassageError("Could not activate user", err);
-      })
-      .then((res) => {
-        return res.data.user;
-      });
 
-    return userData;
-  }
-
-  /**
+    /**
    * Create a user.
    *
    * @param {CreateUserPayload} payload To create the user.
    * @return {Promise<UserObject>} Passage User object
    */
-  async create(payload: CreateUserPayload): Promise<UserObject> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed");
+    async create(payload: CreateUserPayload): Promise<UserObject> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed");
+        }
+        const userData: UserObject = await axios
+            .post(
+                `https://api.passage.id/v1/apps/${this.#appID}/users/`,
+                payload,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not create user", err);
+            })
+            .then((res) => {
+                return res.data.user;
+            });
+        return userData;
     }
-    const userData: UserObject = await axios
-      .post(
-        `https://api.passage.id/v1/apps/${this.#appID}/users/`,
-        payload,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not create user", err);
-      })
-      .then((res) => {
-        return res.data.user;
-      });
-    return userData;
-  }
 
-  /**
+    /**
    * Delete a user using their user ID.
    *
    * @param {string} userID The userID used to delete the corresponding user.
    * Either an E164 phone number or email address.
    * @return {boolean} True if user was deleted, false if not
    */
-  async delete(userID: string): Promise<boolean> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed");
+    async delete(userID: string): Promise<boolean> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed");
+        }
+        const response: number = await axios
+            .delete(
+                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not delete user.", err);
+            })
+            .then((res) => {
+                return res.status.valueOf();
+            });
+
+        return response === 200;
     }
-    const response: number = await axios
-      .delete(
-        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}`,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not delete user.", err);
-      })
-      .then((res) => {
-        return res.status.valueOf();
-      });
 
-    return response === 200;
-  }
-
-  /**
+    /**
    * Get a user's devices using their user ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<Array<WebAuthnDevices>>} List of devices
    */
-  async listDevices(userID: string): Promise<Array<WebAuthnDevices>> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed");
+    async listDevices(userID: string): Promise<Array<WebAuthnDevices>> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed");
+        }
+
+        const devices: Array<WebAuthnDevices> = await axios
+            .get(
+                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/devices`,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not fetch user's devices.", err);
+            })
+            .then((res) => {
+                return res.data.devices;
+            });
+
+        return devices;
     }
 
-    const devices: Array<WebAuthnDevices> = await axios
-      .get(
-        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/devices`,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not fetch user's devices.", err);
-      })
-      .then((res) => {
-        return res.data.devices;
-      });
-
-    return devices;
-  }
-
-  /**
+    /**
    * Revoke a user's device using their user ID and the device ID.
    *
    * @param {string} userID The Passage user ID
    * @param {string} deviceID The Passage user's device ID
    * @return {Promise<boolean>}
    */
-  async revokeDevice(userID: string, deviceID: string): Promise<boolean> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed");
+    async revokeDevice(userID: string, deviceID: string): Promise<boolean> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed");
+        }
+
+        const success: boolean = await axios
+            .delete(
+                `https://api.passage.id/v1/apps/${
+                    this.#appID
+                }/users/${userID}/devices/${deviceID}`,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not delete user's device", err);
+            })
+            .then(() => {
+                return true;
+            });
+
+        return success;
     }
 
-    const success: boolean = await axios
-      .delete(
-        `https://api.passage.id/v1/apps/${
-          this.#appID
-        }/users/${userID}/devices/${deviceID}`,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not delete user's device", err);
-      })
-      .then(() => {
-        return true;
-      });
-
-    return success;
-  }
-
-  /**
+    /**
    * Revokes all of a user's Refresh Tokens using their User ID.
    *
    * @param {string} userID The Passage user ID
    * @return {Promise<boolean>}
    */
-  async signOut(userID: string): Promise<boolean> {
-    if (!this.#apiKey) {
-      throw new PassageError("A Passage API key is needed");
-    }
+    async signOut(userID: string): Promise<boolean> {
+        if (!this.#apiKey) {
+            throw new PassageError("A Passage API key is needed");
+        }
 
-    return axios
-      .delete(
-        `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/tokens/`,
-        this.#authorizationHeader
-      )
-      .catch((err: AxiosError) => {
-        throw new PassageError("Could not revoke user's refresh tokens.", err);
-      })
-      .then(() => {
-        return true;
-      });
-  }
+        return axios
+            .delete(
+                `https://api.passage.id/v1/apps/${this.#appID}/users/${userID}/tokens/`,
+                this.#authorizationHeader
+            )
+            .catch((err: AxiosError) => {
+                throw new PassageError("Could not revoke user's refresh tokens.", err);
+            })
+            .then(() => {
+                return true;
+            });
+    }
 }

--- a/tests/PassageError.test.ts
+++ b/tests/PassageError.test.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from "axios";
+import { PassageError } from "../src/classes/PassageError";
+
+describe("PassageError", () => {
+  test("message only", async () => {
+    const msg =
+      "Could not find valid cookie for authentication. You must catch this error.";
+    const err = new PassageError(msg);
+
+    expect(err.message).toEqual(msg);
+    expect(err.error).toBeUndefined;
+  });
+
+  test("with Axios Error", async () => {
+    const responseData = {
+      error: "some error message",
+    };
+
+    const response: AxiosResponse = {
+      data: responseData,
+      statusText: "Internal Server Error",
+      status: 500,
+    } as AxiosResponse;
+
+    const axiosError = {
+      config: {},
+      request: {},
+      response: response,
+    } as AxiosError<any>;
+
+    const msg =
+      "Could not find valid cookie for authentication. You must catch this error.";
+    const err = new PassageError(msg, axiosError);
+
+    expect(err.message).toEqual(msg);
+    expect(err.statusCode).toBe(500);
+    expect(err.statusText).toBe("Internal Server Error");
+
+    expect(err.error).toBe("some error message");
+  });
+});


### PR DESCRIPTION
PassageError class now containes these fields:
`message` -> descriptive information regarding the error from the sdk
`statusCode` (optional) -> api status code from an API request to the passage backend
`statusText` (optional) -> api status text from an API request to the passage backend
`error` (optional) -> api descriptive error from an API request to the passage backend