### PR TITLE
PSG-1017: parse cookies without regex

### DIFF
--- a/change/@passageidentity-passage-node-a23ef356-4302-4f88-9eac-11791798e708.json
+++ b/change/@passageidentity-passage-node-a23ef356-4302-4f88-9eac-11791798e708.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "PSG-1017: parse cookies without regex",
+  "packageName": "@passageidentity/passage-node",
+  "email": "luis.ramirez@passage.id",
+  "dependentChangeType": "patch"
+}

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -150,18 +150,21 @@ export default class Passage {
             );
         }
 
-        const cookies: Record<string, string> = {};
-
-        cookiesStr.split(";").forEach((cookie) => {
+        const cookies = cookiesStr.split(";");
+        let passageAuthToken;
+        for (const cookie of cookies) {
             const sepIdx = cookie.indexOf("=");
-            if (sepIdx !== -1) {
-                const key = cookie.slice(0, sepIdx).trim();
-                const value = cookie.slice(sepIdx + 1).trim();
-                cookies[key] = value;
+            if (sepIdx === -1) {
+                continue;
             }
-        });
+            const key = cookie.slice(0, sepIdx).trim();
+            if (key !== "psg_auth_token") {
+                continue;
+            }
+            passageAuthToken = cookie.slice(sepIdx + 1).trim();
+            break;
+        }
 
-        const passageAuthToken = cookies.psg_auth_token;
         if (passageAuthToken) {
             const userID = await this.validAuthToken(passageAuthToken);
             if (userID) return userID;
@@ -176,6 +179,7 @@ export default class Passage {
             );
         }
     }
+
 
     /**
    *

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -143,20 +143,20 @@ export default class Passage {
    * @return {string} UserID for Passage User
    */
     async authenticateRequestWithCookie(req: Request): Promise<string> {
-        if (!req.headers?.cookie) {
+        const cookiesStr = req.headers?.cookie;
+        if (!cookiesStr) {
             throw new Error(
                 "Could not find valid cookie for authentication. You must catch this error."
             );
         }
 
-        const cookies = {} as { psg_auth_token: string };
+        const cookies: Record<string, string> = {};
 
-        req.headers.cookie?.split(";").forEach((cookie) => {
-            const parts = cookie.match(/(.*?)=(.*)$/);
-            if (parts) {
-                const key = parts[1].trim();
-                const value = parts[2].trim() || "";
-                // @ts-ignore
+        cookiesStr.split(";").forEach((cookie) => {
+            const sepIdx = cookie.indexOf("=");
+            if (sepIdx !== -1) {
+                const key = cookie.slice(0, sepIdx).trim();
+                const value = cookie.slice(sepIdx + 1).trim();
                 cookies[key] = value;
             }
         });

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -180,7 +180,6 @@ export default class Passage {
         }
     }
 
-
     /**
    *
    * @param {string} kid the KID from the authToken to determine which JWK to use.


### PR DESCRIPTION
### Overview of Changes in this PR

-   parse cookies without regex

### Links

[String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice)
[String.prototype.indexOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf)
[for...of](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of)