### PR TITLE
Enforce email, phone, or user_id in the type system

### DIFF
--- a/change/@passageidentity-passage-node-593f8b6c-f86b-4e4e-b8d6-0d032abde9af.json
+++ b/change/@passageidentity-passage-node-593f8b6c-f86b-4e4e-b8d6-0d032abde9af.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "patch",
   "comment": "Improve typing for MagicLinkRequest",
   "packageName": "@passageidentity/passage-node",
   "email": "kevin.flanagan@passage.id",

--- a/change/@passageidentity-passage-node-593f8b6c-f86b-4e4e-b8d6-0d032abde9af.json
+++ b/change/@passageidentity-passage-node-593f8b6c-f86b-4e4e-b8d6-0d032abde9af.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Improve typing for MagicLinkRequest",
+  "packageName": "@passageidentity/passage-node",
+  "email": "kevin.flanagan@passage.id",
+  "dependentChangeType": "patch"
+}

--- a/src/types/MagicLink.ts
+++ b/src/types/MagicLink.ts
@@ -11,19 +11,28 @@ export type MagicLinkObject = {
   url: string;
 };
 
-enum ChannelEnum {
+export enum ChannelEnum {
   email = "email",
   phone = "phone",
 }
 export type ChannelType = keyof typeof ChannelEnum;
 
-export type MagicLinkRequest = {
+interface MagicLinkRequestProps {
   user_id: string;
   email: string;
   phone: string;
-  channel: ChannelEnum;
   send: boolean;
+  channel: ChannelType;
   magic_link_path: string;
   redirect_url: string;
   language: string;
-};
+  ttl: number;
+}
+
+/** MagicLinkRequest must contain at least one of an email, phone, or user_id property. Note, if you set a value for the send property you must also set a value for the channel.*/
+export type MagicLinkRequest = Partial<MagicLinkRequestProps> &
+  (
+    | Pick<MagicLinkRequestProps, "email">
+    | Pick<MagicLinkRequestProps, "phone">
+    | Pick<MagicLinkRequestProps, "user_id">
+  );

--- a/tests/test-suite.test.ts
+++ b/tests/test-suite.test.ts
@@ -60,8 +60,10 @@ describe("Passage API Requests", () => {
       const magicLink = await passage.createMagicLink({
         email: "chris@passage.id",
         channel: "email",
-      } as MagicLinkRequest);
+        ttl: 12,
+      });
       expect(magicLink).toHaveProperty("identifier", "chris@passage.id");
+      expect(magicLink).toHaveProperty("ttl", 12);
     });
 
     test("Get App", async () => {


### PR DESCRIPTION
### Description
The MagicLinkRequest only requires the presence of an email, phone, or user_id prop, the others are optional. This should be enforced by the defined type in TypeScript

### Implementation
To encode this in the type system I'm redefining MagicLinkRequest in this way:
```
export type MagicLinkRequest = Partial<MagicLinkRequestProps> & (
    | Pick<MagicLinkRequestProps, "email">
    | Pick<MagicLinkRequestProps, "phone">
    | Pick<MagicLinkRequestProps, "user_id">
  );
```
This is a complex type so this is how it works:
`MagicLinkRequestProps` is the full list of properties that this request supports - if we used this type directly (as we did) then all properties would be required. The actual MagicLinkRequest is made of two parts:
- `Partial<MagicLinkRequestProps>`: The Partial<> tag makes a type where all child properties are optional.
- `( | Pick<...> | Pick<...> | Pick<...>)`:
    - `Pick<MagicLinkRequestProps, "email">`: The Pick<> tag makes a type that is a single property subset of the parent type
    - `( | Pick<...> | Pick<...> | Pick<...>)`: The `|` is a [type union](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html) - which takes type types and creates a new type where the result could be either type (or in this case its a three-way type union). This produces a type of object that must have an email, phone, or user_id field. 
    
Finally these two pieces are tied together with the `&` symbol which is a [type intersection](https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#intersection-types). So the final type is the intersection of the full list of optional properties from the first half and the union type which enforces the presence of either `email`, `phone`, or `user_id`.

### Testing
- Existing tests pass.
- Test suite updated to no longer cast the field to circumvent the type system.