### PR TITLE
Fix Replace JWKS Lookup with Jose createRemoteJWKSet

### DIFF
--- a/change/@passageidentity-passage-node-816361ae-3333-498d-b33b-cfbaf3b1dc94.json
+++ b/change/@passageidentity-passage-node-816361ae-3333-498d-b33b-cfbaf3b1dc94.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Replace JWKS Lookup with Jose createRemoteJWKSet",
+    "packageName": "@passageidentity/passage-node",
+    "email": "1934806+himichaelroberts@users.noreply.github.com",
+    "dependentChangeType": "patch"
+}

--- a/tests/test-suite.test.ts
+++ b/tests/test-suite.test.ts
@@ -2,7 +2,6 @@
 import Passage from '../src/index';
 import request from 'supertest';
 import app from '../testServer';
-import { decodeProtectedHeader, importJWK, exportSPKI, KeyLike } from 'jose';
 
 require('dotenv').config();
 
@@ -21,16 +20,6 @@ describe('Passage Initialization', () => {
         apiKey: process.env.API_KEY,
     };
     const passage = new Passage(config);
-
-    test('fetchJWKS', async () => {
-        const jwks = await passage.fetchJWKS();
-        const { kid } = decodeProtectedHeader(appToken);
-        const jwk = jwks[kid as string];
-        const key = await importJWK(jwk);
-        const spkiPem = await exportSPKI(key as KeyLike);
-
-        expect(spkiPem).toContain(process.env.PUBLIC_KEY);
-    });
 
     // note that the current token is only valid until Nov.8 2022
     test('authenticateRequestWithCookie', async () => {


### PR DESCRIPTION
Next.js middleware runs within an edge function that doesn't support node HTTP, a dependency of Axios that we use.

As a workaround, I'm dropping our cache implementation for the use of [Jose createRemoteJWKSet](https://github.com/panva/jose/blob/main/docs/functions/jwks_remote.createRemoteJWKSet.md), which supports node, edge functions, and the browser.