### PR TITLE
PSG-2287: add type to magic link request type

### DIFF
--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -162,12 +162,14 @@ export default class Passage {
      * @return {Promise<MagicLinkObject>} Passage MagicLink object
      */
     async createMagicLink(magicLinkReq: MagicLinkRequest): Promise<MagicLinkObject> {
-        const magicLinkData: MagicLinkObject = await axios
-            .post(`https://api.passage.id/v1/apps/${this.appID}/magic-links/`, magicLinkReq, {
-                headers: {
-                    Authorization: `Bearer ${this.#apiKey}`,
-                },
-            })
+        const magicLinkData: MagicLinkObject = await 
+        fetch(`https://api.passage.id/v1/apps/${this.appID}/magic-links/`, {
+            method: 'POST',
+            body: JSON.stringify(magicLinkReq),
+            headers: {
+                Authorization: `Bearer ${this.#apiKey}`,
+            },
+        })
             .catch((err) => {
                 throw new PassageError('Could not create a magic link for this app.', err);
             })

--- a/src/types/MagicLink.ts
+++ b/src/types/MagicLink.ts
@@ -27,6 +27,7 @@ interface MagicLinkRequestProps {
     redirect_url: string;
     language: string;
     ttl: number;
+    type: string;
 }
 
 /** MagicLinkRequest must contain at least one of an email, phone, or user_id property. Note, if you set a value for the send property you must also set a value for the channel.*/


### PR DESCRIPTION
CreateMagicLink should allow sending a type parameter of "login" or "verify_identifier" (default to login for backwards compatibility). I chose not to hardcode the supported options in here and just handle it in the backend, but open to suggestions on that.