### PR TITLE
Improve token error handling

### DIFF
--- a/change/@passageidentity-passage-node-449b6393-3042-409b-97b3-c4cfb15bf8dc.json
+++ b/change/@passageidentity-passage-node-449b6393-3042-409b-97b3-c4cfb15bf8dc.json
@@ -1,0 +1,9 @@
+{
+    "type": "patch",
+    "comment": {
+        "title": ""
+    },
+    "packageName": "@passageidentity/passage-node",
+    "email": "vanessa.burroughs@passage.id",
+    "dependentChangeType": "patch"
+}

--- a/change/@passageidentity-passage-node-449b6393-3042-409b-97b3-c4cfb15bf8dc.json
+++ b/change/@passageidentity-passage-node-449b6393-3042-409b-97b3-c4cfb15bf8dc.json
@@ -1,7 +1,7 @@
 {
     "type": "patch",
     "comment": {
-        "title": ""
+        "title": "Improve token errors"
     },
     "packageName": "@passageidentity/passage-node",
     "email": "vanessa.burroughs@passage.id",

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -150,11 +150,13 @@ export default class Passage {
                 payload: { sub: userID },
             } = await jwtVerify(token, this.jwks);
             if (userID) return userID.toString();
-            
-            
+
             throw new PassageError('Could not verify token identity. You must catch this error.');
         } catch (e) {
-            throw new PassageError('Could not verify token. You must catch this error.');
+            if (e instanceof Error)
+                throw new PassageError(`Could not verify token: ${e.toString()}. You must catch this error.`);
+
+            throw new PassageError(`Could not verify token. You must catch this error.`);
         }
     }
 

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -137,22 +137,24 @@ export default class Passage {
      * respective public key.
      *
      * @param {string} token Authentication token
-     * @return {string} sub claim if the jwt can be verified, or undefined
+     * @return {string} sub claim if the jwt can be verified, or Error
      */
     async validAuthToken(token: string): Promise<string | undefined> {
         try {
             const { kid } = decodeProtectedHeader(token);
             if (!kid) {
-                return undefined;
+                throw new PassageError('Could not find valid cookie for authentication. You must catch this error.');
             }
 
             const {
                 payload: { sub: userID },
             } = await jwtVerify(token, this.jwks);
             if (userID) return userID.toString();
-            else return undefined;
+            
+            
+            throw new PassageError('Could not verify token identity. You must catch this error.');
         } catch (e) {
-            return undefined;
+            throw new PassageError('Could not verify token. You must catch this error.');
         }
     }
 

--- a/tests/test-suite.test.ts
+++ b/tests/test-suite.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import Passage from '../src/index';
+import { PassageError } from '../src/classes/PassageError';
 import request from 'supertest';
 import app from '../testServer';
 
@@ -45,9 +46,8 @@ describe('Passage Initialization', () => {
         expect(userIdFromToken).toBe(userID);
     });
 
-    test('invalidAuthToken', async () => {
-        const userID = await passage.validAuthToken('invalid_token');
-        expect(userID).toBe(undefined);
+    test('invalidAuthToken', () => {
+        expect(async () => await passage.validAuthToken('invalid_token')).rejects.toThrow(PassageError);
     });
 });
 


### PR DESCRIPTION
## Description

Currently, nothing is returned if the authorization errors are missing. This PR return errors when the correct authorization header is missing.