### PR TITLE
Pin Beachball Version and Include Changelog in NPM Package

### DIFF
--- a/change/@passageidentity-passage-node-9d46d8e5-fb94-4aef-9b46-56c0c9f9d189.json
+++ b/change/@passageidentity-passage-node-9d46d8e5-fb94-4aef-9b46-56c0c9f9d189.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Include changelog in published package",
+    "packageName": "@passageidentity/passage-node",
+    "email": "kevin.flanagan@passage.id",
+    "dependentChangeType": "patch"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.8.0",
                 "@typescript-eslint/parser": "^5.8.0",
                 "babel-jest": "^27.2.0",
-                "beachball": "^2.20.0",
+                "beachball": "2.36.0",
                 "dotenv": "^10.0.0",
                 "eslint": "^8.5.0",
                 "eslint-config-google": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "@typescript-eslint/eslint-plugin": "^5.8.0",
         "@typescript-eslint/parser": "^5.8.0",
         "babel-jest": "^27.2.0",
-        "beachball": "^2.20.0",
+        "beachball": "2.36.0",
         "dotenv": "^10.0.0",
         "eslint": "^8.5.0",
         "eslint-config-google": "^0.14.0",
@@ -30,7 +30,8 @@
     "main": "./lib/cjs/index.js",
     "module": "./lib/esm/index.js",
     "files": [
-        "lib/"
+        "lib/",
+        "CHANGELOG.md"
     ],
     "scripts": {
         "lint": "eslint 'src/**/*.ts?(x)' --fix",


### PR DESCRIPTION
Pin beachball to version 2.36.0 as it is a known working version.
Add CHANGELOG.md to published NPM package.