### PR TITLE
PSG-4017: fix es modules export error

### DIFF
--- a/change/@passageidentity-passage-node-9334068c-a545-4ffc-903e-7ee20f414891.json
+++ b/change/@passageidentity-passage-node-9334068c-a545-4ffc-903e-7ee20f414891.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "fix: removes modules.exports to correctly uses the esm export syntax",
+    "packageName": "@passageidentity/passage-node",
+    "email": "chris.tran@agilebits.com",
+    "dependentChangeType": "patch"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,4 @@ export {
     WebAuthnDevices,
 } from './generated';
 
-module.exports = Passage;
-
 export default Passage;


### PR DESCRIPTION
Removes the `modules.exports = Passage` line to comply with the ESM export syntax