### PR TITLE
Fixing publint error and warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
     },
     "name": "@passageidentity/passage-node",
     "main": "./dist/index.js",
+    "type": "commonjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {
+            "types": "./dist/index.d.ts",
             "require": "./dist/index.js",
-            "import": "./dist/index.mjs",
-            "types": "./dist/index.d.ts"
+            "import": "./dist/index.mjs"
         }
     },
     "files": [


### PR DESCRIPTION
The types field needs to be first in the exports object and no type is specified. This should fix all of the publint issues for the package.

Reference: https://publint.dev/@passageidentity/passage-node@2.11.0