### PR TITLE
PSG-4065: fix PassageError error messages

### DIFF
--- a/change/@passageidentity-passage-node-d5c189a6-010b-4d00-ba9c-76adf79341d0.json
+++ b/change/@passageidentity-passage-node-d5c189a6-010b-4d00-ba9c-76adf79341d0.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "fix: API error messages are now correctly mapped to the PassageError class",
+    "packageName": "@passageidentity/passage-node",
+    "email": "chris.tran@agilebits.com",
+    "dependentChangeType": "patch"
+}

--- a/src/classes/Passage.ts
+++ b/src/classes/Passage.ts
@@ -178,7 +178,11 @@ export class Passage {
 
             return response.magic_link;
         } catch (err) {
-            throw new PassageError('Could not create a magic link for this app.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not create a magic link for this app');
+            }
+
+            throw err;
         }
     }
 
@@ -199,7 +203,11 @@ export class Passage {
 
             return response.app;
         } catch (err) {
-            throw new PassageError('Could not fetch app.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not fetch app');
+            }
+
+            throw err;
         }
     }
 }

--- a/src/classes/PassageError.ts
+++ b/src/classes/PassageError.ts
@@ -4,24 +4,36 @@ import { ResponseError } from '../generated';
  * Passage Class
  */
 export class PassageError extends Error {
+    override name: 'PassageError' = 'PassageError';
     readonly statusCode: number | undefined;
     readonly error: string | undefined;
     readonly message: string;
 
     /**
      * Initialize a new PassageError instance.
-     * @param {string} message friendly message,
-     * @param {Error} err error from node-fetch request
+     * @param {string} message friendly message
+     * @param {ResponseError} err error from http request
      */
     constructor(message: string, err?: ResponseError) {
         super();
 
         if (err) {
-            this.message = `${message}: ${err.message}`;
+            this.message = message;
             this.statusCode = 500;
             this.error = err.message;
         } else {
             this.message = message;
         }
+    }
+
+    /**
+     * Maps a ResponseError to a PassageError.
+     * @param {error} err ResponseError
+     * @param {string} message ResponseError
+     * @return {PassageError} PassageError
+     */
+    public static async fromResponseError(err: ResponseError, message?: string): Promise<PassageError> {
+        const response: { code: string; error: string } = await err.response.json();
+        return new PassageError(`${message}: ${response.error}`, err);
     }
 }

--- a/src/classes/User.ts
+++ b/src/classes/User.ts
@@ -66,7 +66,11 @@ export default class User {
 
             return response.user;
         } catch (err) {
-            throw new PassageError('Could not fetch user.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not fetch user');
+            }
+
+            throw err;
         }
     }
 
@@ -92,9 +96,12 @@ export default class User {
             }
 
             return this.get(users[0].id);
-
         } catch (err) {
-            throw new PassageError('Could not fetch user by identifier.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not fetch user by identifier');
+            }
+
+            throw err;
         }
     }
 
@@ -115,7 +122,11 @@ export default class User {
 
             return response.user;
         } catch (err) {
-            throw new PassageError('Could not deactivate user.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not deactivate user');
+            }
+
+            throw err;
         }
     }
 
@@ -138,7 +149,11 @@ export default class User {
 
             return response.user;
         } catch (err) {
-            throw new PassageError('Could not update user.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not update user');
+            }
+
+            throw err;
         }
     }
 
@@ -158,7 +173,11 @@ export default class User {
             });
             return response.user;
         } catch (err) {
-            throw new PassageError('Could not activate user', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not activate user');
+            }
+
+            throw err;
         }
     }
 
@@ -179,7 +198,11 @@ export default class User {
 
             return response.user;
         } catch (err) {
-            throw new PassageError('Could not create user', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not create user');
+            }
+
+            throw err;
         }
     }
 
@@ -201,7 +224,11 @@ export default class User {
 
             return true;
         } catch (err) {
-            throw new PassageError('Could not delete user.', err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, 'Could not delete user');
+            }
+
+            throw err;
         }
     }
 
@@ -224,7 +251,11 @@ export default class User {
 
             return response.devices;
         } catch (err) {
-            throw new PassageError("Could not fetch user's devices.", err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, "Could not fetch user's devices:");
+            }
+
+            throw err;
         }
     }
 
@@ -249,7 +280,11 @@ export default class User {
 
             return true;
         } catch (err) {
-            throw new PassageError("Could not delete user's device", err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, "Could not delete user's device:");
+            }
+
+            throw err;
         }
     }
 
@@ -271,7 +306,11 @@ export default class User {
             });
             return true;
         } catch (err) {
-            throw new PassageError("Could not revoke user's refresh tokens.", err as ResponseError);
+            if (err instanceof ResponseError) {
+                throw await PassageError.fromResponseError(err, "Could not revoke user's refresh tokens:");
+            }
+
+            throw err;
         }
     }
 }

--- a/tests/PassageError.test.ts
+++ b/tests/PassageError.test.ts
@@ -19,9 +19,30 @@ describe('PassageError', () => {
         const msg = 'Could not find valid cookie for authentication. You must catch this error';
         const err = new PassageError(msg, responseError);
 
-        expect(err.message).toEqual(`${msg}: ${responseError.message}`);
+        expect(err.message).toEqual(msg);
         expect(err.statusCode).toBe(500);
 
         expect(err.error).toBe('some error message');
+    });
+
+    test('fromResponseError', async () => {
+        const responseError = {
+            message: 'some error message',
+            name: 'ResponseError',
+            response: {
+                json: async () => ({
+                    code: 'some code',
+                    error: 'some error',
+                }),
+            },
+        } as ResponseError;
+
+        const msg = 'Failed to do something';
+        const err = await PassageError.fromResponseError(responseError, msg);
+
+        expect(err.message).toEqual(`${msg}: some error`);
+        expect(err.statusCode).toBe(500);
+        expect(err.error).toBe('some error message');
+        expect(`${err}`).toEqual('PassageError: Failed to do something: some error');
     });
 });


### PR DESCRIPTION
Fixes the message mapping and stringified value of `PassageError`.

Before:
```
Could not create a magic link for this app.: Response returned an error code
```

After:
```
PassageError: Could not create a magic link for this app: Invalid access token
```