### PR TITLE
chore: use readonly tag like we do in passage-flex-node

### DIFF
--- a/src/classes/Auth/Auth.ts
+++ b/src/classes/Auth/Auth.ts
@@ -14,7 +14,7 @@ import { CreateMagicLinkRequest, MagicLink, MagicLinksApi, ResponseError } from 
  * Auth class that provides methods for validating JWTs and creating Magic Links.
  */
 export class Auth extends PassageBase {
-    private jwks: (protectedHeader?: JWSHeaderParameters, token?: FlattenedJWSInput) => Promise<KeyLike>;
+    private readonly jwks: (protectedHeader?: JWSHeaderParameters, token?: FlattenedJWSInput) => Promise<KeyLike>;
 
     /**
      * Auth class constructor.

--- a/src/classes/Passage/Passage.ts
+++ b/src/classes/Passage/Passage.ts
@@ -13,13 +13,13 @@ import { User } from '../User';
  * Passage Class
  */
 export class Passage {
-    private appId: string;
+    private readonly appId: string;
     #apiKey: string | undefined;
-    private authStrategy: AuthStrategy;
-    public user: User;
-    public auth: Auth;
+    private readonly authStrategy: AuthStrategy;
+    public readonly user: User;
+    public readonly auth: Auth;
 
-    private _apiConfiguration: Configuration;
+    private readonly _apiConfiguration: Configuration;
 
     /**
      * Initialize a new Passage instance.

--- a/src/classes/User/User.ts
+++ b/src/classes/User/User.ts
@@ -15,8 +15,8 @@ import { PassageUser } from './types';
  * User class for handling operations to get and update user information.
  */
 export class User extends PassageBase {
-    private usersApi;
-    private userDevicesApi;
+    private readonly usersApi: UsersApi;
+    private readonly userDevicesApi: UserDevicesApi;
 
     /**
      * User class constructor.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

After refacoring passage-flex-node I adopted the use of the `readonly` tag. Bringing this to passage-node.

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing integration and unit tests pass locally with my changes
